### PR TITLE
fix for latest 'Encode'

### DIFF
--- a/t/01_utf8.t
+++ b/t/01_utf8.t
@@ -30,7 +30,7 @@ SKIP: {
   require Encode;
   # [RT #84244] wrong complaint: JSON::XS double encodes to ["I â¤ perl"]
   #             and with utf8 triple encodes it to ["I Ã¢ÂÂ¤ perl"]
-  if ($Encode::VERSION < 2.40) { # Encode stricter check: Cannot decode string with wide characters
+  if ($Encode::VERSION < 2.40 || $Encode::VERSION >= 2.54) { # Encode stricter check: Cannot decode string with wide characters
     # see also http://stackoverflow.com/questions/12994100/perl-encode-pm-cannot-decode-string-with-wide-character
     $love = "I \342\235\244 perl";
   }


### PR DESCRIPTION
I got following error with Encode 2.54. `decode_utf8` cannot take decoded string from Encode 2.54.
See Also https://github.com/dankogai/p5-encode/pull/11

```
% prove -bv t/01_utf8.t
t/01_utf8.t .. 
1..13
ok 1
ok 2
ok 3
ok 4
ok 5
ok 6
ok 7
ok 8
ok 9
ok 10 - utf8 enc ascii
ok 11 - utf8 enc latin1
Cannot decode string with wide characters at /home/syohei/.plenv/versions/5.18.1/lib/perl5/site_perl/5.18.1/x86_64-linux-thread-multi/Encode.pm line 216.
# Looks like you planned 13 tests but ran 11.
# Looks like your test exited with 255 just after 11.
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 2/13 subtests 

Test Summary Report
-------------------
t/01_utf8.t (Wstat: 65280 Tests: 11 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 13 tests but ran 11.
Files=1, Tests=11,  0 wallclock secs ( 0.03 usr  0.00 sys +  0.02 cusr  0.00 csys =  0.05 CPU)
Result: FAIL
```
