### PR TITLE
simpler handling of RVs

### DIFF
--- a/t/53_readonly.t
+++ b/t/53_readonly.t
@@ -1,0 +1,20 @@
+#!perl
+use strict;
+use warnings;
+BEGIN { $| = 1; print "1..1\n"; }
+use Cpanel::JSON::XS;
+
+my $json = Cpanel::JSON::XS->new->convert_blessed;
+
+sub Foo::TO_JSON {
+    return 1;
+}
+
+my $string = "something";
+my $object = \$string;
+bless $object,'Foo';
+Internals::SvREADONLY($string,1);
+my $hash = {obj=>$object};
+
+my $enc = $json->encode ($hash);
+print $enc eq '{"obj":1}' ? "" : "not ", "ok 1 # $enc\n";


### PR DESCRIPTION
This removes all the complicated work-around for reblessing. Also, a test to make sure we never break serialising refs to readonly values.
I've tested on 5.18.1 and 5.8.9
I sent a similar patch to JSON::XS, but it was refused.