### PR TITLE
avoid calling isa() as a function

### DIFF
--- a/XS.pm
+++ b/XS.pm
@@ -1743,9 +1743,11 @@ if ($INC{'JSON/XS.pm'} and $JSON::XS::VERSION ge "3.00") {
 sub true()  { $true  }
 sub false() { $false }
 
+use Scalar::Util ();
+
 sub is_bool($) {
-  UNIVERSAL::isa($_[0], "JSON::XS::Boolean")
-    or UNIVERSAL::isa($_[0], "JSON::PP::Boolean");
+  Scalar::Util::blessed($_[0]) and
+     ($_[0]->isa("JSON::XS::Boolean") or $_[0]->isa("JSON::PP::Boolean"));
 }
 
 XSLoader::load 'Cpanel::JSON::XS', $VERSION;


### PR DESCRIPTION
convert UNIVERSAL::isa($thing, ...) to $thing->isa(...) according to best practices
(and this also allows an object to override isa() and act like a ::Boolean)

