### PR TITLE
No protocol slap fights in the docs

### DIFF
--- a/XS.pm
+++ b/XS.pm
@@ -1640,9 +1640,6 @@ conservative, the default nesting limit is set to 512. If your process
 has a smaller stack, you should adjust this setting accordingly with the
 C<max_depth> method.
 
-Something else could bomb you, too, that I forgot to think of. In that
-case, you get to keep the pieces. I am always open for hints, though...
-
 Also keep in mind that Cpanel::JSON::XS might leak contents of your Perl data
 structures in its error messages, so when you serialise sensitive
 information you might want to make sure that exceptions thrown by JSON::XS


### PR DESCRIPTION
This patch removes a long standing irksome bit in the JSON::XS docs.  This protocol slap fight is of no use to the user and has no place in module documentation.  Only the bits which are relevant to the user have been left in.

If YAML compatibility is a practical concern, write an "as_yaml" method to work around the problems.  Far more useful to the user than carefully enumerating the minute problems.

I also cleaned up a handful of overly chatty bits of the docs and references to "I".
