### PR TITLE
Fix callback stack mishandling

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -852,6 +852,7 @@ encode_rv (pTHX_ enc_t *enc, SV *sv)
 
           PUTBACK;
           count = call_sv ((SV *)GvCV (method), G_ARRAY);
+          const int items = count;
           SPAGAIN;
 
           /* catch this surprisingly common error */
@@ -875,6 +876,7 @@ encode_rv (pTHX_ enc_t *enc, SV *sv)
 
           encode_ch (aTHX_ enc, ']');
 
+          SP -= items;
           PUTBACK;
 
           FREETMPS; LEAVE;
@@ -2181,12 +2183,13 @@ decode_hv (pTHX_ dec_t *dec)
               if (count == 1)
                 {
                   sv = newSVsv (POPs);
-                  FREETMPS; LEAVE;
+                  PUTBACK; FREETMPS; LEAVE;
                   return sv;
                 }
 
               SvREFCNT_inc (sv);
-              FREETMPS; LEAVE;
+              SP -= count;
+              PUTBACK; FREETMPS; LEAVE;
             }
         }
 
@@ -2203,12 +2206,13 @@ decode_hv (pTHX_ dec_t *dec)
           if (count == 1)
             {
               sv = newSVsv (POPs);
-              FREETMPS; LEAVE;
+              PUTBACK; FREETMPS; LEAVE;
               return sv;
             }
 
           SvREFCNT_inc (sv);
-          FREETMPS; LEAVE;
+          SP -= count;
+          PUTBACK; FREETMPS; LEAVE;
         }
     }
 

--- a/t/23_array_ctx.t
+++ b/t/23_array_ctx.t
@@ -1,0 +1,19 @@
+print "1..5\n";
+use Cpanel::JSON::XS;
+
+sub FREEZE { ( 123, 456 ); }
+@foo = Cpanel::JSON::XS->new->allow_tags->encode(bless {}, 'main');
+
+print "ok 1\n";
+
+@foo = Cpanel::JSON::XS->new->filter_json_object(sub {12})->decode('[{}]');
+print "ok 2\n";
+
+@foo = Cpanel::JSON::XS->new->filter_json_object(sub {return shift, 1})->decode('[{}, {}]');
+print "ok 3\n";
+
+@foo = Cpanel::JSON::XS->new->filter_json_single_key_object(1 => sub { [] })->decode('{"1":0}');
+print "ok 4\n";
+
+@foo = Cpanel::JSON::XS->new->filter_json_single_key_object(1 => sub { [], [] })->decode('{"1":0}');
+print "ok 5\n";


### PR DESCRIPTION
When decode/encode gets called in a list context (for ex., when constructing lists/hash values), and they uses perl callbacks, stack may get misaligned, that leads to crashes of the perl interpreter.
