### PR TITLE
fix stack corruption when encoding nested objects with FREEZE method

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -33,6 +33,7 @@ t/20_faihu.t
 t/21_evans.t
 t/22_comment_at_eof.t
 t/23_array_ctx.t
+t/24_freeze_recursion.t
 t/52_object.t
 t/96_interop.t
 t/97_unshare_hek.t

--- a/XS.xs
+++ b/XS.xs
@@ -893,6 +893,7 @@ encode_rv (pTHX_ enc_t *enc, SV *sv)
           while (count)
             {
               encode_sv (aTHX_ enc, SP[1 - count--]);
+              SPAGAIN;
 
               if (count)
                 encode_ch (aTHX_ enc, ',');

--- a/t/24_freeze_recursion.t
+++ b/t/24_freeze_recursion.t
@@ -1,0 +1,24 @@
+use Cpanel::JSON::XS;
+use strict;
+print "1..1\n";
+
+my @foo_params = map {( "foo$_" => 1 )} 1..61;
+my $foo = Foo->new(@foo_params);
+my $encoded = Cpanel::JSON::XS->new()->allow_tags(1)->encode(
+    Foo->new(
+        foo => Foo->new(@foo_params),
+        bar => Foo->new(foo => $foo),
+    )
+);
+print defined($encoded) ? "ok 1\n" : "nok 1\n";
+
+package Foo;
+
+sub new {
+    my $class = shift;
+    return bless {@_}, $class;
+}
+
+sub FREEZE {
+    return %{ $_[0] };
+}


### PR DESCRIPTION
encode_sv call may again call FREEZE method, resulting in stack pointer relocation, so we must re-fetch it before accessing SP again.