### PR TITLE
only skip hash keys sorting for actually tied hashes

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -738,7 +738,7 @@ encode_hv (pTHX_ enc_t *enc, HV *hv)
 
   /* for canonical output we have to sort by keys first */
   /* caused by randomised hash orderings */
-  if (enc->json.flags & F_CANONICAL && !SvRMAGICAL (hv))
+  if (enc->json.flags & F_CANONICAL && !SvTIED_mg((SV*)hv, PERL_MAGIC_tied))
     {
       int count = hv_iterinit (hv);
 


### PR DESCRIPTION
As of version 2.25, JSON::XS announced that it won't sort tied hashes under the 'canonical' option. But it's implementation covered too broad range of magic - SvRMAGICAL is set for any magic other then mg_get/mg_set upon cast.

It was discovered in the https://github.com/garu/Data-Printer/issues/75 issue that the core module Hash::Util::FieldHash can easily produce hashes that won't be sorted by JSON::XS::encode_json  despite being not tie'd.