### PR TITLE
Ignore allow_barekey if we detect quotes

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -2339,6 +2339,8 @@ decode_hv (pTHX_ dec_t *dec)
   else
     for (;;)
       {
+        int is_bare = allow_barekey;
+
         if (expect_false(allow_barekey
                          && *dec->cur >= 'A' && *dec->cur <= 'z'))
           ;
@@ -2348,9 +2350,11 @@ decode_hv (pTHX_ dec_t *dec)
           }
           else if (*dec->cur == 0x27)
             endstr = 0x27;
+          is_bare=0;
           ++dec->cur;
         } else {
           EXPECT_CH ('"');
+          is_bare=0;
         }
 
         /* heuristic: assume that */
@@ -2366,7 +2370,7 @@ decode_hv (pTHX_ dec_t *dec)
           for (;;)
             {
               /* the >= 0x80 is false on most architectures */
-              if (!allow_barekey &&
+              if (!is_bare &&
                   (p == e || *p < 0x20 || *(U8*)p >= 0x80 || *p == '\\'
                    || allow_squote))
                 {
@@ -2391,7 +2395,7 @@ decode_hv (pTHX_ dec_t *dec)
                   break;
                 }
               else if (*p == endstr
-                       || (allow_barekey &&
+                       || (is_bare &&
                            (*p == ':' || *p == ' ' || *p == 0x0a
                             || *p == 0x0d || *p == 0x09)))
                 {

--- a/t/107_allow_singlequote.t
+++ b/t/107_allow_singlequote.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 4;
+use Test::More tests => 5;
 use strict;
 use Cpanel::JSON::XS;
 #########################
@@ -16,3 +16,4 @@ is($json->decode(q|{'foo':"bar"}|)->{foo}, 'bar');
 is($json->decode(q|{'foo':'bar'}|)->{foo}, 'bar');
 is($json->allow_barekey->decode(q|{foo:'bar'}|)->{foo}, 'bar');
 
+is($json->decode(q|{'foo baz':'bar'}|)->{"foo baz"}, 'bar');

--- a/t/17_relaxed.t
+++ b/t/17_relaxed.t
@@ -1,4 +1,4 @@
-use Test::More $] < 5.008 ? (skip_all => "5.6") : (tests => 11);
+use Test::More $] < 5.008 ? (skip_all => "5.6") : (tests => 12);
 use Cpanel::JSON::XS;
 
 my $json = Cpanel::JSON::XS->new->relaxed;
@@ -17,3 +17,5 @@ ok (!eval { $json->decode ('{,}') });
 is (encode_json $json->decode ("[1#,2\n ,2,#  ]  \n\t]"), '[1,2]');
 
 is (encode_json $json->decode ("[\"Hello\tWorld\"]"), '["Hello\tWorld"]');
+
+is (encode_json $json->decode ('{"a b":2}'),    '{"a b":2}'); # allow_barekey


### PR DESCRIPTION
Work around allow_barekey when we detect an initial quote, to prevent breaking quoted keys with whitespace when the option is enabled: see https://github.com/rurban/Cpanel-JSON-XS/issues/51