### PR TITLE
only run pod tests for the author

### DIFF
--- a/t/z_pod.t
+++ b/t/z_pod.t
@@ -1,5 +1,10 @@
 # -*- perl -*-
+use strict;
 use Test::More;
+
+plan skip_all => 'This test is only run for the module author'
+  unless -d '.git' || $ENV{AUTHOR_TESTING};
+
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 all_pod_files_ok();


### PR DESCRIPTION
Over time, the pod parser can change and the test can unexpectedly start failing for users.