### PR TITLE
Encode integer NOK scalars as floats

### DIFF
--- a/t/03_types.t
+++ b/t/03_types.t
@@ -1,4 +1,4 @@
-BEGIN { $| = 1; print "1..84\n"; }
+BEGIN { $| = 1; print "1..85\n"; }
 use utf8;
 use Cpanel::JSON::XS;
 
@@ -64,6 +64,8 @@ for $v (1, 2, 3, 5, -1, -2, -3, -4, 100, 1000, 10000, -999, -88, -7, 7, 88, 999,
    ok ($v == ((decode_json "[$v]")->[0]));
    ok ($v == ((decode_json encode_json [$v])->[0]));
 }
+
+ok ('[1.0]' eq encode_json [1.0]);
 
 ok (30123 == ((decode_json encode_json [30123])->[0]));
 ok (32123 == ((decode_json encode_json [32123])->[0]));

--- a/t/117_numbers.t
+++ b/t/117_numbers.t
@@ -57,4 +57,4 @@ is encode_json({test => [$num, $str]}), '{"test":[1,"0 but true"]}', 'int/string
 
 $str = 'bar';
 { no warnings "numeric"; $num = 23 + $str }
-is encode_json({test => [$num, $str]}), '{"test":[23,"bar"]}', , 'int/string dualvar';
+is encode_json({test => [$num, $str]}), '{"test":[23.0,"bar"]}', , 'int/string dualvar';

--- a/t/11_pc_expo.t
+++ b/t/11_pc_expo.t
@@ -20,7 +20,7 @@ $js  = q|[-1.234e5]|;
 $obj = $pc->decode($js);
 is($obj->[0], -123400, 'digit -1.234e5');
 $js = $pc->encode($obj);
-is($js,'[-123400]', 'digit -1.234e5');
+is($js,'[-123400.0]', 'digit -1.234e5');
 
 $js  = q|[1.23E-4]|;
 $obj = $pc->decode($js);


### PR DESCRIPTION
This commit outputs a trailing ".0" for scalars that are NOK but have
integer values (that do not require scientific notation).  Doing so
transmits what limited type information we can for consumption by more
strongly-typed languages.

There is one other significant behavior change to note: scalars resulting
from addition of numeric and non-numeric data wind up NOK (e.g. "42" +
"bar").

This is a non-trivial behavior change compared to other JSON encoders, but Cpanel's fork prioritizes round-trip integrity and this would ensure NV->JSON->NV for integers.