### PR TITLE
t/20_unknown.t fails if older JSON::PP installed

### DIFF
--- a/t/20_unknown.t
+++ b/t/20_unknown.t
@@ -3,7 +3,7 @@ use strict;
 use Test::More;
 BEGIN {
   # allow_unknown method added to JSON::PP in 2.09
-  eval 'use JSON 2.09 ();'
+  eval 'use JSON 2.09 (); 1'
     or plan skip_all => 'JSON 2.09 required for cross testing';
   $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }

--- a/t/20_unknown.t
+++ b/t/20_unknown.t
@@ -2,8 +2,9 @@
 use strict;
 use Test::More;
 BEGIN {
-  eval 'require JSON;'
-    or plan skip_all => 'JSON required for cross testing';
+  # allow_unknown method added to JSON::PP in 2.09
+  eval 'use JSON 2.09 ();'
+    or plan skip_all => 'JSON 2.09 required for cross testing';
   $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }
 plan tests => 32;


### PR DESCRIPTION
`t/20_unknown.t` tries to compare the `allow_unknown` behavior of `JSON:PP` and `Cpanel::JSON::XS`.  However, the `allow_unknown` method was added to `JSON::PP` in version 2.09.  If you have an older version of `JSON` installed, the test fails instead of being skipped like it should be.

This change adds a version check so the tests will be skipped unless a new-enough version of `JSON` is installed.

Although I have to say I'm not sure it makes sense to be testing a module that's not part of the distribution being installed, or even a prerequisite.