### PR TITLE
add option disallow_dupkeys

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -38,6 +38,7 @@ t/22_comment_at_eof.t
 t/23_array_ctx.t
 t/24_freeze_recursion.t
 t/25_boolean.t
+t/26_duplicate.t
 t/30_jsonspec.t
 t/31_bom.t
 t/52_object.t

--- a/README
+++ b/README
@@ -608,6 +608,13 @@ OBJECT-ORIENTED INTERFACE
 
             $json->allow_barekey->decode('{foo:"bar"}');
 
+    $json = $json->disallow_dupkeys ([$enable])
+    $enabled = $json->get_disallow_dupkeys
+            $json = $json->disallow_dupkeys([$enable])
+
+        If $enable is true (or missing), then "decode" will throw an error
+        if a JSON object repeats a key.
+
     $json = $json->allow_bignum ([$enable])
     $enabled = $json->get_allow_bignum
             $json = $json->allow_bignum([$enable])

--- a/XS.pm
+++ b/XS.pm
@@ -706,6 +706,16 @@ application-specific files written by humans.
     $json->allow_barekey->decode('{foo:"bar"}');
 
 
+=item $json = $json->disallow_dupkeys ([$enable])
+
+=item $enabled = $json->get_disallow_dupkeys
+
+    $json = $json->disallow_dupkeys([$enable])
+
+If C<$enable> is true (or missing), then C<decode> will throw an error
+if a JSON object repeats a key.
+
+
 =item $json = $json->allow_bignum ([$enable])
 
 =item $enabled = $json->get_allow_bignum

--- a/t/26_duplicate.t
+++ b/t/26_duplicate.t
@@ -1,0 +1,11 @@
+use Test::More tests => 4;
+use Cpanel::JSON::XS;
+
+my $json = Cpanel::JSON::XS->new;
+
+is (encode_json $json->decode ('{"a":"b","a":"c"}'), '{"a":"c"}'); # t/test_parsing/y_object_duplicated_key.json
+is (encode_json $json->decode ('{"a":"b","a":"b"}'), '{"a":"b"}'); # t/test_parsing/y_object_duplicated_key_and_value.json
+
+$json->disallow_dupkeys;
+ok (!eval { $json->decode ('{"a":"b","a":"c"}') }); # t/test_parsing/y_object_duplicated_key.json
+ok (!eval { $json->decode ('{"a":"b","a":"b"}') }); # t/test_parsing/y_object_duplicated_key_and_value.json


### PR DESCRIPTION
The JSON spec allows duplicate name in objects, however Perl hashes do not, and parsing JSON in Perl silently ignores duplicate names, using the last value found.

The option disallow_dupkeys, when enabled, will instead throw an error when duplicate names are found. It is useful in some cases to know when the JSON being parsed has values which will be ignored.

A similar pull request has been done for JSON-PP: https://github.com/makamaka/JSON-PP/pull/30

Note: I am very much a novice with XS code.