### PR TITLE
When 'allow_bignum' is enabled, floats and big integers inside structures are not properly decoded

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -2529,7 +2529,7 @@ decode_num (pTHX_ dec_t *dec)
 
       if (dec->json.flags & F_ALLOW_BIGNUM) {
         SV* pv = newSVpvs("require Math::BigInt && return Math::BigInt->new(\"");
-        sv_catpv(pv, start);
+        sv_catpvn(pv, start, dec->cur - start);
         sv_catpvs(pv, "\");");
         eval_sv(pv, G_SCALAR);
         SvREFCNT_dec(pv);
@@ -2547,7 +2547,7 @@ decode_num (pTHX_ dec_t *dec)
 
   if (dec->json.flags & F_ALLOW_BIGNUM) {
     SV* pv = newSVpvs("require Math::BigFloat && return Math::BigFloat->new(\"");
-    sv_catpv(pv, start);
+    sv_catpvn(pv, start, dec->cur - start);
     sv_catpvs(pv, "\");");
     eval_sv(pv, G_SCALAR);
     SvREFCNT_dec(pv);

--- a/t/110_bignum.t
+++ b/t/110_bignum.t
@@ -5,7 +5,7 @@ BEGIN {
   eval q| require Math::BigInt |;
   $has_bignum = $@ ? 0 : 1;
 }
-use Test::More $has_bignum ? (tests => 6) : (skip_all => "Can't load Math::BigInt");
+use Test::More $has_bignum ? (tests => 10) : (skip_all => "Can't load Math::BigInt");
 use Cpanel::JSON::XS;
 use Devel::Peek;
 
@@ -38,3 +38,17 @@ is("$num", '2.0000000000000000001', 'decode bigfloat') or Dump $num;
 $e = $json->encode($num);
 is($e, '2.0000000000000000001', 'encode bigfloat') or Dump $e;
 
+my $num = $json->decode(q|[100000000000000000000000000000000000000]|)->[0];
+
+isa_ok( $num, 'Math::BigInt' );
+is(
+    "$num",
+    $fix . '100000000000000000000000000000000000000',
+    'decode bigint inside structure'
+) or Dump($num);
+
+$num = $json->decode(q|[2.0000000000000000001]|)->[0];
+isa_ok( $num, 'Math::BigFloat' );
+
+is( "$num", '2.0000000000000000001', 'decode bigfloat inside structure' )
+  or Dump $num;


### PR DESCRIPTION
When trying to decode JSON strings that contain floats inside structures, with 'allow_bignum' enabled, I got warnings about syntax errors in eval.

As far as I understood, the code to create the Math::Big(Int|Float) objects in decode took all the JSON string from the beginning of the number to the end of JSON string (instead of just to the end of the number).

Added a couple of tests to illustrate the issue.

Thank you rurban for this great module!