### PR TITLE
stringify true booleans as 1

### DIFF
--- a/XS.pm
+++ b/XS.pm
@@ -2194,11 +2194,11 @@ BEGIN {
     "0+"     => sub { ${$_[0]} },
     "++"     => sub { $_[0] = ${$_[0]} + 1 },
     "--"     => sub { $_[0] = ${$_[0]} - 1 },
-    '""'     => sub { ${$_[0]} == 1 ? 'true' : '0' }, # GH 29
+    '""'     => sub { ${$_[0]} == 1 ? '1' : '0' }, # GH 29
     'eq'     => sub {
       my ($obj, $op) = ref ($_[0]) ? ($_[0], $_[1]) : ($_[1], $_[0]);
       if ($op eq 'true' or $op eq 'false') {
-        return "$obj" eq 'true' ? 'true' eq $op : 'false' eq $op;
+        return "$obj" eq '1' ? 'true' eq $op : 'false' eq $op;
       }
       else {
         return $obj ? 1 == $op : 0 == $op;

--- a/t/03_types.t
+++ b/t/03_types.t
@@ -22,7 +22,7 @@ ok ($true eq "true", "true: eq $true");
 ok ("$false" eq "0",     "false: stringified $false eq 0");
 #ok ("$false" eq "false", "false: stringified $false eq false");
 #ok ("$true" eq "1",    "true: stringified $true eq 1");
-ok ("$true" eq "true", "true: stringified $true");
+ok ("$true" eq "1", "true: stringified $true");
 {
   my $FH;
   my $fn = "tmp_$$";
@@ -32,7 +32,7 @@ ok ("$true" eq "true", "true: stringified $true");
   open $FH, "<", $fn;
   my $s = <$FH>;
   close $FH;
-  ok ($s eq "0true\n", $s); # 11
+  ok ($s eq "01\n", $s); # 11
   unlink $fn;
 }
 


### PR DESCRIPTION
1 is a standard true boolean value in perl.  Using a different breaks
modules that are expecting a normal perl boolean.  Moose's Bool type is
one example of this.  Additionally, this avoids the action at a distance
where just loading Cpanel::JSON::XS would change how JSON::PP and
JSON::XS stringified their booleans.

Fixes GH#61