### PR TITLE
[Work in progress] Cpanel::JSON::XS: use Data::Bool

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,6 +52,7 @@ WriteMakefile(
   NAME         => "Cpanel::JSON::XS",
   PREREQ_PM    => {
     'Pod::Text'     => '2.08',
+    'Types::Bool'   => '0',
   },
   DEFINE       => $define,
   LICENSE      => 'perl',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -52,7 +52,7 @@ WriteMakefile(
   NAME         => "Cpanel::JSON::XS",
   PREREQ_PM    => {
     'Pod::Text'     => '2.08',
-    'Types::Bool'   => '0',
+    'Data::Bool'    => '0',
   },
   DEFINE       => $define,
   LICENSE      => 'perl',

--- a/XS.pm
+++ b/XS.pm
@@ -2203,7 +2203,7 @@ sub allow_bigint {
     Carp::carp("allow_bigint() is obsoleted. use allow_bignum() instead.");
 }
 
-use Types::Bool qw(true false);
+use Data::Bool qw(true false);
 
 BEGIN {
   package
@@ -2235,7 +2235,7 @@ our ($true, $false) = (true, false);
 sub is_bool($) {
   shift if @_ == 2; # as method call
   (ref($_[0]) and UNIVERSAL::isa( $_[0], JSON::PP::Boolean::))
-  or Types::Bool::is_bool($_[0])
+  or Data::Bool::is_bool($_[0])
 }
 
 XSLoader::load 'Cpanel::JSON::XS', $XS_VERSION;

--- a/XS.pm
+++ b/XS.pm
@@ -2211,7 +2211,6 @@ BEGIN {
 
   require overload;
 
-  local $^W; # silence redefine warnings. no warnings 'redefine' does not help
   &overload::import( 'overload', # workaround 5.6 reserved keyword warning
     '""'     => sub { ${$_[0]} == 1 ? '1' : '0' }, # GH 29
     'eq'     => sub {

--- a/XS.pm
+++ b/XS.pm
@@ -2234,8 +2234,8 @@ our ($true, $false) = (true, false);
 
 sub is_bool($) {
   shift if @_ == 2; # as method call
-  (ref($_[0]) and UNIVERSAL::isa( $_[0], JSON::PP::Boolean::))
-  or Data::Bool::is_bool($_[0])
+  (ref($_[0]) and UNIVERSAL::isa( $_[0], Data::Bool::BOOL_PACKAGE))
+  or (exists $INC{'Types/Serialiser.pm'} and Types::Serialiser::is_bool($_[0]))
 }
 
 XSLoader::load 'Cpanel::JSON::XS', $XS_VERSION;


### PR DESCRIPTION
I am opening a discussion for moving the boolean support of JSON modules (like [JSON::PP](https://github.com/makamaka/JSON-PP/pull/36), JSON::XS, and Cpanel::JSON::XS) to other module, which can be used as the common interfaces for other Perl modules which need booleans as objects and which are interested in interoperability.

I am working on trial version of Types::Bool and the latest release on CPAN is: https://metacpan.org/release/FERREIRA/Types-Bool-2.98005-TRIAL

Let me know what you think of that.