### PR TITLE
Escape html unsafe strings

### DIFF
--- a/README
+++ b/README
@@ -76,6 +76,12 @@ DESCRIPTION
         This module has both a simple functional interface as well as an
         object oriented interface.
 
+    *   HTML-safe by default
+
+        This module escapes HTML characters (&, <, >) with JSON
+        "\u"-notation. The resulting JSON is safe to embed in HTML page
+        without additional HTML-escaping.
+
     *   reasonably versatile output formats
 
         You can choose between the most compact guaranteed-single-line
@@ -589,16 +595,20 @@ OBJECT-ORIENTED INTERFACE
 
         This setting has currently no effect on tied hashes.
 
+    $json = $json->dont_escape_html ([$enable])
+    $dont_escape = $json->get_dont_escape_html
+        By default HTML-unsafe characters (&, < and >) in strings are
+        escaped using JSON "\u"-notation. If you are sure that generated
+        JSON is not going to be embedded in HTML and you want to save some
+        bytes you can use this method to disable this escaping.
+
+        See L/SECURITY CONSIDERATIONS>, below, for more info on this.
+
     $json = $json->escape_slash ([$enable])
     $enabled = $json->get_escape_slash
-        According to the JSON Grammar, the *forward slash* character
-        (U+002F) "/" need to be escaped. But by default strings are encoded
-        without escaping slashes in all perl JSON encoders.
-
-        If $enable is true (or missing), then "encode" will escape slashes,
-        "\/".
-
-        This setting has no effect when decoding JSON texts.
+        This method is no longer recommended because Cpan::JSON::XS now
+        generates HTML-safe JSON by default, see "Embedding JSON in HTML"
+        chapter.
 
     $json = $json->unblessed_bool ([$enable])
     $enabled = $json->get_unblessed_bool
@@ -1946,14 +1956,37 @@ SECURITY CONSIDERATIONS
     information you might want to make sure that exceptions thrown by
     JSON::XS will not end up in front of untrusted eyes.
 
-    If you are using Cpanel::JSON::XS to return packets to consumption by
-    JavaScript scripts in a browser you should have a look at
-    <http://blog.archive.jpsykes.com/47/practical-csrf-and-json-security/>
-    to see whether you are vulnerable to some common attack vectors (which
-    really are browser design bugs, but it is still you who will have to
-    deal with it, as major browser developers care only for features, not
-    about getting security right). You might also want to also look at
-    Mojo::JSON special escape rules to prevent from XSS attacks.
+  Embedding JSON in HTML
+    Cpanel::JSON::XS by default escapes HTML-unsafe characters (&, gt and
+    lt) in strings using JSON "\u"-notation. This allows to directly embed
+    generated JSON in <script> tags in HTML source without the usual
+    HTML-escaping (using "&lt;", "&gt;" and "&amp;").
+
+    The problem with HTML escaping is that every hash key and every string
+    is encoded with double quotes that are converted to six bytes
+    ("&quot;"). This may substantially increase the size of JSON contents
+    and reduce readability of HTML source code.
+
+    If you embed JSON in <script> tag without any escaping you may be
+    exposed to XSS attack vulnerability. Here is an example:
+
+        <script>{"foo": "</script><script>window.alert(1)</script>"}</script>
+
+    Here the string containing closing </script> tag closes the outer tag
+    and then immediately starts the new script tag that will contain
+    attacker-controlled code that is going to be executed.
+
+    Naive attempts to fix the problem by detecting end-tags with regexes
+    often forget that a) tag names are case-insensitive and b) there could
+    be spaces between "</script" and "gt".
+
+    With default behaviour of Cpanel::JSON::XS the example code would look
+    like this:
+
+        <script>{"foo": "\u003c/script\u003e\u003cscript\u003ewindow.alert(1)\u003c/script\u003c"}</script>
+
+    This code does not contain unsafe characters inside raw strings and is
+    not vulnerable to the describe attack.
 
 "OLD" VS. "NEW" JSON (RFC 4627 VS. RFC 7159)
     TL;DR: Due to security concerns, Cpanel::JSON::XS will not allow scalar

--- a/XS.pm
+++ b/XS.pm
@@ -2180,7 +2180,7 @@ be spaces between C<</script> and C<L<gt>>.
 With default behaviour of Cpanel::JSON::XS the example code would look
 like this:
 
-    <script>{"foo": "\u003c\u003escript\u003e\u003cscript\u003ewindow.alert(1)\u003c/script\u003c"}</script>
+    <script>{"foo": "\u003c/script\u003e\u003cscript\u003ewindow.alert(1)\u003c/script\u003c"}</script>
 
 This code does not contain unsafe characters inside raw strings and is
 not vulnerable to the describe attack.

--- a/XS.xs
+++ b/XS.xs
@@ -277,6 +277,7 @@ mingw_modfl(long double x, long double *ip)
 #define F_SORT_BY         0x00100000UL
 #define F_ALLOW_STRINGIFY 0x00200000UL
 #define F_UNBLESSED_BOOL  0x00400000UL
+#define F_DONT_ESCAPE_HTML 0x00800000UL
 #define F_HOOK            0x80000000UL /* some hooks exist, so slow-path processing */
 
 #define F_PRETTY    F_INDENT | F_SPACE_BEFORE | F_SPACE_AFTER
@@ -803,7 +804,7 @@ encode_str (pTHX_ enc_t *enc, char *str, STRLEN len, int is_utf8)
               *enc->cur++ = '\\';
               ++len;
             }
-          else if (UNLIKELY((ch == '&' || ch == '<' || ch == '>') && !(enc->json.flags & F_BINARY)))
+          else if (UNLIKELY((ch == '&' || ch == '<' || ch == '>') && !(enc->json.flags & F_BINARY) && !(enc->json.flags & F_DONT_ESCAPE_HTML)))
             {
               need (aTHX_ enc, 6);
               sprintf (enc->cur, "\\u%04x", ch);
@@ -4116,6 +4117,7 @@ void ascii (JSON *self, int enable = 1)
         escape_slash    = F_ESCAPE_SLASH
         allow_stringify = F_ALLOW_STRINGIFY
         unblessed_bool  = F_UNBLESSED_BOOL
+        dont_escape_html = F_DONT_ESCAPE_HTML
     PPCODE:
         if (enable)
           self->flags |=  ix;
@@ -4146,6 +4148,7 @@ void get_ascii (JSON *self)
         get_escape_slash    = F_ESCAPE_SLASH
         get_allow_stringify  = F_ALLOW_STRINGIFY
         get_unblessed_bool  = F_UNBLESSED_BOOL
+        get_dont_escape_html = F_DONT_ESCAPE_HTML
     PPCODE:
         XPUSHs (boolSV (self->flags & ix));
 

--- a/XS.xs
+++ b/XS.xs
@@ -859,7 +859,7 @@ encode_str (pTHX_ enc_t *enc, char *str, STRLEN len, int is_utf8)
                       clen = 1;
                     }
 
-                  if (uch < 0x80/*0x20*/ || uch >= enc->limit)
+                  if (uch < 0x80/*0x20*/ || uch >= enc->limit || ((uch == 0x2028 || uch == 0x2029) && !(enc->json.flags & F_DONT_ESCAPE_HTML)))
                     {
 		      if (enc->json.flags & F_BINARY)
 			{

--- a/XS.xs
+++ b/XS.xs
@@ -803,6 +803,13 @@ encode_str (pTHX_ enc_t *enc, char *str, STRLEN len, int is_utf8)
               *enc->cur++ = '\\';
               ++len;
             }
+          else if (UNLIKELY((ch == '&' || ch == '<' || ch == '>') && !(enc->json.flags & F_BINARY)))
+            {
+              need (aTHX_ enc, 6);
+              sprintf (enc->cur, "\\u%04x", ch);
+              enc->cur += 6;
+              ++len;
+            }
           else if (UNLIKELY(ch == '/' && (enc->json.flags & F_ESCAPE_SLASH)))
             {
               need (aTHX_ enc, 2);

--- a/t/120_escape_html.t
+++ b/t/120_escape_html.t
@@ -13,6 +13,7 @@ my $json_unescaped = Cpanel::JSON::XS->new->allow_nonref->dont_escape_html;
 
 is($json_unescaped->encode($hash), '{"<script>":"\"&\""}');
 
+skip "5.6", 2 if $] < 5.008;
 my $extra_hash = { "\x{2028}" => "\x{2029}" };
 is($json->encode($extra_hash), '{"\u2028":"\u2029"}');
 is($json_unescaped->encode($extra_hash), "{\"\x{2028}\":\"\x{2029}\"}");

--- a/t/120_escape_html.t
+++ b/t/120_escape_html.t
@@ -1,4 +1,4 @@
-use Test::More tests => 2;
+use Test::More tests => 4;
 use Cpanel::JSON::XS;
 use warnings;
 #########################
@@ -12,3 +12,7 @@ is($json->encode($hash), '{"\u003cscript\u003e":"\"\u0026\""}');
 my $json_unescaped = Cpanel::JSON::XS->new->allow_nonref->dont_escape_html;
 
 is($json_unescaped->encode($hash), '{"<script>":"\"&\""}');
+
+my $extra_hash = { "\x{2028}" => "\x{2029}" };
+is($json->encode($extra_hash), '{"\u2028":"\u2029"}');
+is($json_unescaped->encode($extra_hash), "{\"\x{2028}\":\"\x{2029}\"}");

--- a/t/120_escape_html.t
+++ b/t/120_escape_html.t
@@ -1,4 +1,4 @@
-use Test::More tests => 1;
+use Test::More tests => 2;
 use Cpanel::JSON::XS;
 use warnings;
 #########################
@@ -8,3 +8,7 @@ my $json = Cpanel::JSON::XS->new->allow_nonref;
 my $hash = { "<script>" => "\"&\"" };
 
 is($json->encode($hash), '{"\u003cscript\u003e":"\"\u0026\""}');
+
+my $json_unescaped = Cpanel::JSON::XS->new->allow_nonref->dont_escape_html;
+
+is($json_unescaped->encode($hash), '{"<script>":"\"&\""}');

--- a/t/120_escape_html.t
+++ b/t/120_escape_html.t
@@ -1,0 +1,10 @@
+use Test::More tests => 1;
+use Cpanel::JSON::XS;
+use warnings;
+#########################
+
+my $json = Cpanel::JSON::XS->new->allow_nonref;
+
+my $hash = { "<script>" => "\"&\"" };
+
+is($json->encode($hash), '{"\u003cscript\u003e":"\"\u0026\""}');

--- a/t/54_stringify.t
+++ b/t/54_stringify.t
@@ -35,7 +35,7 @@ package main;
 my $object = bless ["foo"], 'Foo';
 my $enc = $json->encode( { obj => $object } );
 
-is( $enc, '{"obj":"Foo <foo>"}', "mg object stringified" )
+is( $enc, '{"obj":"Foo \u003cfoo\u003e"}', "mg object stringified" )
   or diag($enc);
 
 $enc = $json->encode( { time => $time } );


### PR DESCRIPTION
By default escape HTML characters in JSON strings with JSON \u-notation.  The resulting JSON is safe to embed in HTML page without additional HTML-escaping.

This should make things safer because many people do not understand security considerations.