### PR TITLE
Fix ->unblessed_bool to produce modifiable perl structures

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -3602,7 +3602,7 @@ decode_sv (pTHX_ dec_t *dec, SV *typesv)
             if (typesv)
               sv_setiv_mg (typesv, JSON_TYPE_BOOL);
             if (dec->json.flags & F_UNBLESSED_BOOL)
-              return &PL_sv_yes;
+              return newSVsv (&PL_sv_yes);
             return newSVsv(MY_CXT.json_true);
           }
         else
@@ -3618,7 +3618,7 @@ decode_sv (pTHX_ dec_t *dec, SV *typesv)
             if (typesv)
               sv_setiv_mg (typesv, JSON_TYPE_BOOL);
             if (dec->json.flags & F_UNBLESSED_BOOL)
-              return &PL_sv_no;
+              return newSVsv (&PL_sv_no);
             return newSVsv(MY_CXT.json_false);
           }
         else

--- a/t/25_boolean.t
+++ b/t/25_boolean.t
@@ -1,5 +1,5 @@
 use strict;
-use Test::More tests => 40;
+use Test::More tests => 42;
 use Cpanel::JSON::XS ();
 use Config;
 
@@ -113,5 +113,9 @@ SKIP: {
 cmp_ok($js->{is_false}, "==", 0, "->unblessed_bool for JSON false returns correct Perl bool value");
 cmp_ok($js->{is_false}, "eq", "", "->unblessed_bool for JSON false returns correct Perl bool value");
 
-is($unblessed_bool_cjson->encode($unblessed_bool_cjson->decode($truefalse)), $truefalse, "encode(decode(boolean)) is identity with ->unblessed_bool");
-is($cjson->encode($unblessed_bool_cjson->decode($truefalse)), $truefalse, "booleans decoded by ->unblessed_bool(1) are encoded by ->unblessed_bool(0) in the same way");
+is($unblessed_bool_cjson->encode(do { my $struct = $unblessed_bool_cjson->decode($truefalse, my $types); ($struct, $types) }), $truefalse, "encode(decode(boolean)) is identity with ->unblessed_bool");
+is($cjson->encode(do { my $struct = $unblessed_bool_cjson->decode($truefalse, my $types); ($struct, $types) }), $truefalse, "booleans decoded by ->unblessed_bool(1) are encoded by ->unblessed_bool(0) in the same way");
+
+$js = $unblessed_bool_cjson->decode($truefalse);
+ok eval { $js->[0] = "new value 0" }, "decoded 'true' is modifiable" or diag($@);
+ok eval { $js->[1] = "new value 1" }, "decoded 'false' is modifiable" or diag($@);


### PR DESCRIPTION
If &PL_sv_yes or &PL_sv_no is assigned into perl hash or perl array via XS
code then value in this perl structure is not modifiable and perl throw
following fatal error: Modification of a read-only value attempted

In this change is also test which checks that assigning in perl code is
working fine.

Similar problem was fixed for undef values in commit
0e82667119db46b50436532f86ee357e7673db68