### PR TITLE
Fix inconsistency with warnings in typed json encoder

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1780,7 +1780,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
       bool loc_changed = FALSE;
       char *locale = NULL;
 #endif
-      NV nv = SvNOKp (sv) ? SvNVX (sv) : SvOK (sv) ? SvNV_nomg (sv) : 0;
+      NV nv = SvNOKp (sv) ? SvNVX (sv) : SvNV_nomg (sv);
       /* trust that perl will do the right thing w.r.t. JSON syntax. */
       need (aTHX_ enc, NV_DIG + 32);
       savecur = enc->cur;
@@ -2006,7 +2006,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
               uv = (UV)iv;
             }
         }
-      else if (SvOK (sv))
+      else
         {
           is_neg = 1;
           iv = SvIV_nomg (sv);


### PR DESCRIPTION
Add test which check that encoding to string and to numbers generates same kind of numeric/uninitialized warnings.

Currently encoding undef to JSON_TYPE_STRING results in json with empty string and "Use of uninitialized value" warning is thrown. Encoding undef to JSON_TYPE_STRING_OR_NULL results in json with null value.

After this change, above behavior is also applied for JSON_TYPE_INT, JSON_TYPE_INT_OR_NULL, JSON_TYPE_FLOAT and JSON_TYPE_FLOAT_OR_NULL.

So behavior for typed json encoder is consistent now.