### PR TITLE
Fix typed json encoder conversion from scalar's PV slot to JSON_TYPE_INT

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1686,6 +1686,20 @@ encode_bool (pTHX_ enc_t *enc, SV *sv)
 }
 
 static void
+sv_to_ivuv (pTHX_ SV *sv, int *is_neg, IV *iv, UV *uv)
+{
+  *iv = SvIV_nomg (sv);
+  *uv = (UV)iv;
+  /* SvIV and SvUV may modify SvIsUV flag */
+  *is_neg = !SvIsUV (sv);
+  if (!*is_neg)
+    {
+      *uv = SvUV_nomg (sv);
+      *iv = (IV)uv;
+    }
+}
+
+static void
 encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
 {
   IV type = 0;
@@ -2001,16 +2015,12 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
             }
           else
             {
-              is_neg = 1;
-              iv = SvIV_nomg (sv);
-              uv = (UV)iv;
+              sv_to_ivuv (aTHX_ sv, &is_neg, &iv, &uv);
             }
         }
       else
         {
-          is_neg = 1;
-          iv = SvIV_nomg (sv);
-          uv = (UV)iv;
+          sv_to_ivuv (aTHX_ sv, &is_neg, &iv, &uv);
         }
       if (is_neg ? iv <= 59000 && iv >= -59000
                  : uv <= 59000)


### PR DESCRIPTION
It did not worked correctly for numbers which can be represented by
unsigned type but not by signed type: `[2^(8*IVSIZE-1), 2^(8*IVSIZE)-1]`

`SvIV` and `SvUV` macros may modify `SvIsUV` flag, so after calling `SvIV` it is
needed to check if returned value is signed or unsigned.

This patch fixes it and add tests for scalars with corner cases in `PV` slot.

Values out of range of perl integers are converted for `JSON_TYPE_INT` to
either `IV_MIN` or `UV_MAX` (signed minimal or unsigned maximal represented
value in perl).