### PR TITLE
Add new method ->require_types

### DIFF
--- a/README
+++ b/README
@@ -190,20 +190,21 @@ FUNCTIONAL INTERFACE
 
         This function call is functionally identical to:
 
-           $json_text = Cpanel::JSON::XS->new->utf8->encode ($perl_scalar)
+           $json_text = Cpanel::JSON::XS->new->utf8->encode ($perl_scalar, $json_type)
 
         Except being faster.
 
         For the type argument see Cpanel::JSON::XS::Type.
 
-    $perl_scalar = decode_json $json_text [, $allow_nonref ]
+    $perl_scalar = decode_json $json_text [, $allow_nonref [, my $json_type
+    ] ]
         The opposite of "encode_json": expects an UTF-8 (binary) string of
         an json reference and tries to parse that as an UTF-8 encoded JSON
         text, returning the resulting reference. Croaks on error.
 
         This function call is functionally identical to:
 
-           $perl_scalar = Cpanel::JSON::XS->new->utf8->decode ($json_text)
+           $perl_scalar = Cpanel::JSON::XS->new->utf8->decode ($json_text, $json_type)
 
         except being faster.
 
@@ -215,6 +216,8 @@ FUNCTIONAL INTERFACE
         allow_nonref option will be set and the function will act is
         described as in the relaxed RFC 7159 allowing all values such as
         objects, arrays, strings, numbers, "null", "true", and "false".
+
+        For the type argument see Cpanel::JSON::XS::Type.
 
     $is_boolean = Cpanel::JSON::XS::is_bool $scalar
         Returns true if the passed scalar represents either "JSON::XS::true"
@@ -934,7 +937,7 @@ OBJECT-ORIENTED INTERFACE
         strings. No QNAN/SNAN/negative NAN support, unified to "nan". Much
         easier to detect, but may conflict with valid strings.
 
-    $json_text = $json->encode ($perl_scalar)
+    $json_text = $json->encode ($perl_scalar, $json_type)
         Converts the given Perl data structure (a simple scalar or a
         reference to a hash or array) to its JSON representation. Simple
         scalars will be converted into JSON string or number sequences,
@@ -943,13 +946,17 @@ OBJECT-ORIENTED INTERFACE
         become JSON "null" values. Neither "true" nor "false" values will be
         generated.
 
-    $perl_scalar = $json->decode ($json_text)
+        For the type argument see Cpanel::JSON::XS::Type.
+
+    $perl_scalar = $json->decode ($json_text, my $json_type)
         The opposite of "encode": expects a JSON text and tries to parse it,
         returning the resulting simple scalar or reference. Croaks on error.
 
         JSON numbers and strings become simple Perl scalars. JSON arrays
         become Perl arrayrefs and JSON objects become Perl hashrefs. "true"
         becomes 1, "false" becomes 0 and "null" becomes "undef".
+
+        For the type argument see Cpanel::JSON::XS::Type.
 
     ($perl_scalar, $characters) = $json->decode_prefix ($json_text)
         This works like the "decode" method, but instead of raising an
@@ -1282,7 +1289,10 @@ MAPPING
         precision up to but not including the least significant bit.
 
     true, false
-        These JSON atoms become "Cpanel::JSON::XS::true" and
+        When "unblessed_bool" is set to true, then JSON "true" becomes 1 and
+        JSON "false" becomes 0.
+
+        Otherwise these JSON atoms become "Cpanel::JSON::XS::true" and
         "Cpanel::JSON::XS::false", respectively. They are
         "JSON::PP::Boolean" objects and are overloaded to act almost exactly
         like the numbers 1 and 0. You can check whether a scalar is a JSON
@@ -1384,9 +1394,16 @@ MAPPING
     simple scalars
         Simple Perl scalars (any scalar that is not a reference) are the
         most difficult objects to encode: Cpanel::JSON::XS will encode
-        undefined scalars or inf/nan as JSON "null" values, scalars that
-        have last been used in a string context before encoding as JSON
-        strings, and anything else as number value:
+        undefined scalars or inf/nan as JSON "null" values and other scalars
+        to either number or string in non-deterministic way which may be
+        affected or changed by Perl version or any other loaded Perl module.
+
+        If you want to have stable and deterministic types in JSON encoder
+        then use Cpanel::JSON::XS::Type.
+
+        Non-deterministic behavior is following: scalars that have last been
+        used in a string context before encoding as JSON strings, and
+        anything else as number value:
 
            # dump as number
            encode_json [2]                      # yields [2]

--- a/README
+++ b/README
@@ -707,6 +707,16 @@ OBJECT-ORIENTED INTERFACE
         This option is special to this module, it is not supported by other
         encoders. So it is not recommended to use it.
 
+    $json = $json->require_types ([$enable])
+    $enable = $json->get_require_types
+             $json = $json->require_types([$enable])
+
+        If $enable is true (or missing), then "encode" will require second
+        argument with supplied JSON types. See Cpanel::JSON::XS::Type. When
+        second argument is not provided (or is undef), then "encode" croaks.
+        It also croaks when the type for provided structure in "encode" is
+        incomplete.
+
     $json = $json->allow_dupkeys ([$enable])
     $enabled = $json->get_allow_dupkeys
         If $enable is true (or missing), then the "decode" method will not

--- a/XS.pm
+++ b/XS.pm
@@ -827,6 +827,18 @@ This option does not affect C<decode> in any way.
 This option is special to this module, it is not supported by other
 encoders.  So it is not recommended to use it.
 
+=item $json = $json->require_types ([$enable])
+
+=item $enable = $json->get_require_types
+
+     $json = $json->require_types([$enable])
+
+If C<$enable> is true (or missing), then C<encode> will require
+second argument with supplied JSON types. See L<Cpanel::JSON::XS::Type>.
+When second argument is not provided (or is undef), then C<encode>
+croaks. It also croaks when the type for provided structure in
+C<encode> is incomplete.
+
 =item $json = $json->allow_dupkeys ([$enable])
 
 =item $enabled = $json->get_allow_dupkeys

--- a/XS.pm
+++ b/XS.pm
@@ -238,13 +238,13 @@ Converts the given Perl data structure to a UTF-8 encoded, binary string
 
 This function call is functionally identical to:
 
-   $json_text = Cpanel::JSON::XS->new->utf8->encode ($perl_scalar)
+   $json_text = Cpanel::JSON::XS->new->utf8->encode ($perl_scalar, $json_type)
 
 Except being faster.
 
 For the type argument see L<Cpanel::JSON::XS::Type>.
 
-=item $perl_scalar = decode_json $json_text [, $allow_nonref ]
+=item $perl_scalar = decode_json $json_text [, $allow_nonref [, my $json_type ] ]
 
 The opposite of C<encode_json>: expects an UTF-8 (binary) string of an
 json reference and tries to parse that as an UTF-8 encoded JSON text,
@@ -252,7 +252,7 @@ returning the resulting reference. Croaks on error.
 
 This function call is functionally identical to:
 
-   $perl_scalar = Cpanel::JSON::XS->new->utf8->decode ($json_text)
+   $perl_scalar = Cpanel::JSON::XS->new->utf8->decode ($json_text, $json_type)
 
 except being faster.
 
@@ -264,6 +264,8 @@ If the new optional $allow_nonref argument is set and not false, the
 allow_nonref option will be set and the function will act is described
 as in the relaxed RFC 7159 allowing all values such as objects,
 arrays, strings, numbers, "null", "true", and "false".
+
+For the type argument see L<Cpanel::JSON::XS::Type>.
 
 =item $is_boolean = Cpanel::JSON::XS::is_bool $scalar
 
@@ -1066,7 +1068,7 @@ sprintf(%g), but without double quotes.
 strings.  No QNAN/SNAN/negative NAN support, unified to "nan". Much
 easier to detect, but may conflict with valid strings.
 
-=item $json_text = $json->encode ($perl_scalar)
+=item $json_text = $json->encode ($perl_scalar, $json_type)
 
 Converts the given Perl data structure (a simple scalar or a reference
 to a hash or array) to its JSON representation. Simple scalars will be
@@ -1075,7 +1077,9 @@ arrays become JSON arrays and references to hashes become JSON
 objects. Undefined Perl values (e.g. C<undef>) become JSON C<null>
 values. Neither C<true> nor C<false> values will be generated.
 
-=item $perl_scalar = $json->decode ($json_text)
+For the type argument see L<Cpanel::JSON::XS::Type>.
+
+=item $perl_scalar = $json->decode ($json_text, my $json_type)
 
 The opposite of C<encode>: expects a JSON text and tries to parse it,
 returning the resulting simple scalar or reference. Croaks on error.
@@ -1083,6 +1087,8 @@ returning the resulting simple scalar or reference. Croaks on error.
 JSON numbers and strings become simple Perl scalars. JSON arrays become
 Perl arrayrefs and JSON objects become Perl hashrefs. C<true> becomes
 C<1>, C<false> becomes C<0> and C<null> becomes C<undef>.
+
+For the type argument see L<Cpanel::JSON::XS::Type>.
 
 =item ($perl_scalar, $characters) = $json->decode_prefix ($json_text)
 
@@ -1440,7 +1446,10 @@ up to but not including the least significant bit.
 
 =item true, false
 
-These JSON atoms become C<Cpanel::JSON::XS::true> and
+When C<unblessed_bool> is set to true, then JSON C<true> becomes C<1> and
+JSON C<false> becomes C<0>.
+
+Otherwise these JSON atoms become C<Cpanel::JSON::XS::true> and
 C<Cpanel::JSON::XS::false>, respectively. They are C<JSON::PP::Boolean>
 objects and are overloaded to act almost exactly like the numbers C<1>
 and C<0>. You can check whether a scalar is a JSON boolean by using
@@ -1555,7 +1564,14 @@ your own serializer method.
 
 Simple Perl scalars (any scalar that is not a reference) are the most
 difficult objects to encode: Cpanel::JSON::XS will encode undefined
-scalars or inf/nan as JSON C<null> values, scalars that have last been
+scalars or inf/nan as JSON C<null> values and other scalars to either
+number or string in non-deterministic way which may be affected or
+changed by Perl version or any other loaded Perl module.
+
+If you want to have stable and deterministic types in JSON encoder then
+use L<Cpanel::JSON::XS::Type>.
+
+Non-deterministic behavior is following: scalars that have last been
 used in a string context before encoding as JSON strings, and anything
 else as number value:
 

--- a/XS.xs
+++ b/XS.xs
@@ -278,6 +278,7 @@ mingw_modfl(long double x, long double *ip)
 #define F_ALLOW_STRINGIFY 0x00200000UL
 #define F_UNBLESSED_BOOL  0x00400000UL
 #define F_ALLOW_DUPKEYS   0x00800000UL
+#define F_REQUIRE_TYPES   0x01000000UL
 #define F_HOOK            0x80000000UL /* some hooks exist, so slow-path processing */
 
 #define F_PRETTY    F_INDENT | F_SPACE_BEFORE | F_SPACE_AFTER
@@ -1708,6 +1709,9 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
   int force_conversion = 0;
 
   SvGETMAGIC (sv);
+
+  if (UNLIKELY (!(SvOK (typesv)) && (enc->json.flags & F_REQUIRE_TYPES)))
+    croak ("type for '%s' was not specified", SvPV_nolen (sv));
 
   if (SvROK (sv) && !SvOBJECT (SvRV (sv)))
     {
@@ -4105,6 +4109,7 @@ void ascii (JSON *self, int enable = 1)
         allow_stringify = F_ALLOW_STRINGIFY
         unblessed_bool  = F_UNBLESSED_BOOL
         allow_dupkeys   = F_ALLOW_DUPKEYS
+        require_types   = F_REQUIRE_TYPES
     PPCODE:
         if (enable)
           self->flags |=  ix;
@@ -4136,6 +4141,7 @@ void get_ascii (JSON *self)
         get_allow_stringify = F_ALLOW_STRINGIFY
         get_unblessed_bool  = F_UNBLESSED_BOOL
         get_allow_dupkeys   = F_ALLOW_DUPKEYS
+        get_require_types   = F_REQUIRE_TYPES
     PPCODE:
         XPUSHs (boolSV (self->flags & ix));
 

--- a/XS/Type.pm
+++ b/XS/Type.pm
@@ -83,6 +83,10 @@ does not work reliable for dual vars and scalars which were used in
 both numeric and string operations. See L<simple
 scalars|Cpanel::JSON::XS/simple scalars>.
 
+To enforce that specification is always provided use C<require_types>.
+In this case when C<encode> is called without second argument (or is
+undef) then it croaks. It applies recursively for all sub-structures.
+
 =head2 JSON type specification for scalars:
 
 =over 4

--- a/t/118_type.t
+++ b/t/118_type.t
@@ -14,9 +14,9 @@ BEGIN {
     }
 }
 
-use Test::More tests => 285;
+use Test::More tests => 299;
 
-my $cjson = Cpanel::JSON::XS->new->canonical->allow_nonref;
+my $cjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types;
 
 foreach my $false (Cpanel::JSON::XS::false, undef, 0, 0.0, 0E0, !!0, !1, "0", "", \0) {
     is($cjson->encode($false, JSON_TYPE_BOOL), 'false');
@@ -69,14 +69,12 @@ is($cjson->encode(Cpanel::JSON::XS::false, JSON_TYPE_BOOL), 'false');
 is($cjson->encode(Cpanel::JSON::XS::false, JSON_TYPE_INT), '0');
 is($cjson->encode(Cpanel::JSON::XS::false, JSON_TYPE_FLOAT), '0.0');
 is($cjson->encode(Cpanel::JSON::XS::false, JSON_TYPE_STRING), '"false"');
-is($cjson->encode(Cpanel::JSON::XS::false), 'false');
 is($cjson->encode(Cpanel::JSON::XS::false, json_type_anyof([], {}, JSON_TYPE_BOOL)), 'false');
 
 is($cjson->encode(Cpanel::JSON::XS::true, JSON_TYPE_BOOL), 'true');
 is($cjson->encode(Cpanel::JSON::XS::true, JSON_TYPE_INT), '1');
 is($cjson->encode(Cpanel::JSON::XS::true, JSON_TYPE_FLOAT), '1.0');
 is($cjson->encode(Cpanel::JSON::XS::true, JSON_TYPE_STRING), '"true"');
-is($cjson->encode(Cpanel::JSON::XS::true), 'true');
 is($cjson->encode(Cpanel::JSON::XS::true, json_type_anyof([], {}, JSON_TYPE_BOOL)), 'true');
 
 is($cjson->encode(undef, JSON_TYPE_BOOL_OR_NULL), 'null');
@@ -409,3 +407,27 @@ SKIP: {
     undef $struct;
     ok(!defined $weakref);
 }
+
+ok(!defined eval { $cjson->encode(1) });
+like($@, qr/type for '1' was not specified/);
+
+ok(!defined eval { $cjson->encode(1, undef) });
+like($@, qr/type for '1' was not specified/);
+
+ok(!defined eval { $cjson->encode([1]) });
+like($@, qr/type for 'ARRAY\(.*\)' was not specified/);
+
+ok(!defined eval { $cjson->encode([1], undef) });
+like($@, qr/type for 'ARRAY\(.*\)' was not specified/);
+
+ok(!defined eval { $cjson->encode([1], [undef]) });
+like($@, qr/type for '1' was not specified/);
+
+ok(!defined eval { $cjson->encode({ key => 1 }) });
+like($@, qr/type for 'HASH\(.*\)' was not specified/);
+
+ok(!defined eval { $cjson->encode({ key => 1 }, undef) });
+like($@, qr/type for 'HASH\(.*\)' was not specified/);
+
+ok(!defined eval { $cjson->encode({ key => 1 }, { key => undef }) });
+like($@, qr/type for '1' was not specified/);


### PR DESCRIPTION
When require_types is set then encode method croaks if second type argument
is not provided. This is useful to ensure that Cpanel::JSON::XS encoder
always produce deterministic output.