### PR TITLE
Rethrow error from eval_sv()

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -3178,6 +3178,8 @@ decode_num (pTHX_ dec_t *dec, SV *typesv)
         sv_catpvs(pv, "\");");
         eval_sv(pv, G_SCALAR);
         SvREFCNT_dec(pv);
+        if (SvTRUEx (ERRSV))
+          croak (NULL); /* rethrow current error */
         {
           dSP;
           SV *retval = SvREFCNT_inc(POPs);
@@ -3199,6 +3201,8 @@ decode_num (pTHX_ dec_t *dec, SV *typesv)
     sv_catpvs(pv, "\");");
     eval_sv(pv, G_SCALAR);
     SvREFCNT_dec(pv);
+    if (SvTRUEx (ERRSV))
+      croak (NULL); /* rethrow current error */
     {
       dSP;
       SV *retval = SvREFCNT_inc(POPs);


### PR DESCRIPTION
Function eval_sv() does not croak on error. Instead it puts undef on stack
and set error message to ERRSV ($@). We do not want to return undef when
loading or calling Math::BigInt/BigFloat fails. So ensure that error
message from Math::BigInt/BigFloat is propagated back to the caller.

Calling croak(NULL) would rethrow current error message from ERRSV,
similarly like calling croak_sv(ERRSV). But because croak_sv() is not
supported by older Perl versions, use croak(NULL) construction.