### PR TITLE
Make CPanel::JSON::XS encoder independent on Math::BigInt version

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1430,6 +1430,10 @@ encode_stringify(pTHX_ enc_t *enc, SV *sv, int isref)
       SvREFCNT_dec(rv);
     }
   }
+  if (UNLIKELY(isref == 1 && (enc->json.flags & F_ALLOW_BIGNUM) && str && str[0] == '+')) {
+    str++;
+    len--;
+  }
   /* if ALLOW_BIGNUM and Math::Big* and NaN => according to stringify_infnan */
   if (UNLIKELY(
         (enc->json.flags & F_ALLOW_BIGNUM)

--- a/t/110_bignum.t
+++ b/t/110_bignum.t
@@ -30,7 +30,7 @@ is("$num", $fix . '100000000000000000000000000000000000000', 'decode bigint')
   or Dump ($num);
 
 my $e = $json->encode($num);
-is($e, $fix . '100000000000000000000000000000000000000', 'encode bigint')
+is($e, '100000000000000000000000000000000000000', 'encode bigint')
     or Dump( $e );
 
 $num  = $json->decode(q|2.0000000000000000001|);

--- a/t/110_bignum.t
+++ b/t/110_bignum.t
@@ -11,13 +11,6 @@ use Test::More $has_bignum
 use Cpanel::JSON::XS;
 use Devel::Peek;
 
-my $v = Math::BigInt->VERSION;
-$v =~ s/_.+$// if $v;
-
-my $fix =  !$v ? '+'
-  : $v < 1.6 ? '+'
-  : '';
-
 my $json = new Cpanel::JSON::XS;
 
 $json->allow_nonref->allow_bignum;
@@ -26,7 +19,7 @@ $json->convert_blessed->allow_blessed;
 my $num  = $json->decode(q|100000000000000000000000000000000000000|);
 
 isa_ok($num, 'Math::BigInt');
-is("$num", $fix . '100000000000000000000000000000000000000', 'decode bigint')
+is($num->bcmp('100000000000000000000000000000000000000'), 0, 'decode bigint')
   or Dump ($num);
 
 my $e = $json->encode($num);
@@ -44,8 +37,8 @@ $num = $json->decode(q|[100000000000000000000000000000000000000]|)->[0];
 
 isa_ok( $num, 'Math::BigInt' );
 is(
-    "$num",
-    $fix . '100000000000000000000000000000000000000',
+    $num->bcmp('100000000000000000000000000000000000000'),
+    0,
     'decode bigint inside structure'
 ) or Dump($num);
 


### PR DESCRIPTION
Change CPanel::JSON::XS encoder to always produces same output independently of Math::BigInt version. Also change tests to not depend on Math::BigInt version.