### PR TITLE
Do not allow serializing objects when json type is specified and convert_blessed is not enabled

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -1734,6 +1734,9 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
 
   if (UNLIKELY (SvOK (typesv)))
     {
+      if (SvROK (sv) && SvOBJECT (SvRV (sv)) && !(enc->json.flags & (F_ALLOW_TAGS|F_CONV_BLESSED|F_ALLOW_BLESSED)) && !is_bool_obj (aTHX_ SvRV (sv)) && !is_bignum_obj (aTHX_ SvRV (sv)))
+        croak ("encountered object '%s', but neither allow_blessed, convert_blessed nor allow_tags settings are enabled (or TO_JSON/FREEZE method missing)", SvPV_nolen (sv));
+
       if (!SvIOKp (typesv))
         {
           if (SvROK (typesv) &&

--- a/t/118_type.t
+++ b/t/118_type.t
@@ -17,7 +17,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 333;
+use Test::More tests => 335;
 
 my $cjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types;
 my $bigcjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types->allow_bignum;
@@ -513,3 +513,6 @@ like($@, qr/type for 'HASH\(.*\)' was not specified/);
 
 ok(!defined eval { $cjson->encode({ key => 1 }, { key => undef }) });
 like($@, qr/type for '1' was not specified/);
+
+ok(!defined eval { $cjson->encode(bless({}, 'Object'), JSON_TYPE_STRING) });
+like($@, qr/encountered object.*but neither allow_blessed, convert_blessed nor allow_tags settings are enabled/);


### PR DESCRIPTION
This is current behavior when json type in encode method is not specified
and also reflects documentation about object serialization:
https://metacpan.org/pod/Cpanel::JSON::XS#SERIALIZATION