### PR TITLE
Fix encoding floating point values above 2^64 in PV slot to JSON_TYPE_INT

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -2262,7 +2262,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
                 }
             }
 
-          if ((numtype & IS_NUMBER_GREATER_THAN_UV_MAX) && (enc->json.flags & F_ALLOW_BIGNUM))
+          if ((numtype & (IS_NUMBER_GREATER_THAN_UV_MAX|IS_NUMBER_NOT_INT)) && (enc->json.flags & F_ALLOW_BIGNUM))
             {
               STRLEN len;
               char *str;

--- a/t/118_type.t
+++ b/t/118_type.t
@@ -17,7 +17,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 359;
+use Test::More tests => 360;
 
 my $cjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types;
 my $bigcjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types->allow_bignum;
@@ -181,13 +181,14 @@ is($bigcjson->encode('-9223372036854775809', JSON_TYPE_INT), '-92233720368547758
 is($bigcjson->encode('-9223372036854775810', JSON_TYPE_INT), '-9223372036854775810');  # -2^63-2
 
 SKIP: {
-  skip 'requires Math::BigFloat 1.35', 5 unless eval { Math::BigFloat->VERSION(1.35) };
+  skip 'requires Math::BigFloat 1.35', 6 unless eval { Math::BigFloat->VERSION(1.35) };
   # float string values outside of range [IV_MIN, UV_MAX] with enabled bignum
   is($bigcjson->encode('18446744073709551616.5', JSON_TYPE_INT), '18446744073709551616');  #  2^64
   is($bigcjson->encode('18446744073709551617.5', JSON_TYPE_INT), '18446744073709551617');  #  2^64+1
   is($bigcjson->encode('18446744073709551618.5', JSON_TYPE_INT), '18446744073709551618');  #  2^64+2
   is($bigcjson->encode('-9223372036854775809.5', JSON_TYPE_INT), '-9223372036854775809');  # -2^63-1
   is($bigcjson->encode('-9223372036854775810.5', JSON_TYPE_INT), '-9223372036854775810');  # -2^63-2
+  is($bigcjson->encode(  '7.37869762948382e+19', JSON_TYPE_INT), '73786976294838200000');
 }
 
 # Math::BigInt values outside of range [IV_MIN, UV_MAX] with enabled bignum


### PR DESCRIPTION
Perl function grok_number() does not signal IS_NUMBER_GREATER_THAN_UV_MAX
flag when floating point number cannot be represented in UV slot without
loosing precision. So when ->allow_bignum is enabled and floating point
value is passed, always use conversion from PV slot to big integer via
Math::BigFloat module. Detection is done based on IS_NUMBER_NOT_INT flag.