### PR TITLE
Fix JSON_TYPE_INT encoder with numeric values above 2^64 in PV slot

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -2278,7 +2278,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
             }
         }
 
-      if (SvIOKp (sv))
+      if (SvIOK (sv))
         {
           is_neg = !SvIsUV (sv);
           iv = SvIVX (sv);

--- a/t/118_type.t
+++ b/t/118_type.t
@@ -17,7 +17,7 @@ BEGIN {
     }
 }
 
-use Test::More tests => 380;
+use Test::More tests => 381;
 
 my $cjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types;
 my $bigcjson = Cpanel::JSON::XS->new->canonical->allow_nonref->require_types->allow_bignum;
@@ -298,6 +298,10 @@ SKIP: {
   is($bigcjson->encode(Math::BigFloat->new('inf'), JSON_TYPE_FLOAT), '1.79769313486232e+308');
   is($bigcjson->encode(Math::BigFloat->new('-inf'), JSON_TYPE_FLOAT), '-1.79769313486232e+308');
 }
+
+my $stringified_int = '-9223372036854775810';
+do { my $temp = $stringified_int + 10 };
+is($bigcjson->encode($stringified_int, JSON_TYPE_INT), '-9223372036854775810');
 
 is(encode_json([10, "10", 10.25], [JSON_TYPE_INT, JSON_TYPE_INT, JSON_TYPE_STRING]), '[10,10,"10.25"]');
 is(encode_json([10, "10", 10.25], json_type_arrayof(JSON_TYPE_INT)), '[10,10,10]');


### PR DESCRIPTION
When PV variable was used in numeric context, perl put loose numeric value
in private IV slot. So encoder should not use private IV slot as it
contains either rounded, loose or incorrect value.

So use SvIOK() macro for checking if variable has value in public IV slot.

New test demonstrate this problem. Variable $stringified_int is not
modified, but after "do" block it has private IV slot with rounded value
and public PV slot with correct value. And because encoder used SvIOKp()
check, it got value from private IV slot where was stored rounded value.
Now after this change it does not use private IV slot, but rather public PV
slot where is stored correct unmodified value.