### PR TITLE
Add new method ->type_all_string

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -41,6 +41,7 @@ t/116_incr_parse_fixed.t
 t/117_numbers.t
 t/118_type.t
 t/119_type_decode.t
+t/120_type_all_string.t
 t/11_pc_expo.t
 t/12_blessed.t
 t/13_limit.t

--- a/README
+++ b/README
@@ -716,11 +716,27 @@ OBJECT-ORIENTED INTERFACE
     $enable = $json->get_require_types
              $json = $json->require_types([$enable])
 
-        If $enable is true (or missing), then "encode" will require second
-        argument with supplied JSON types. See Cpanel::JSON::XS::Type. When
-        second argument is not provided (or is undef), then "encode" croaks.
-        It also croaks when the type for provided structure in "encode" is
-        incomplete.
+        If $enable is true (or missing), then "encode" will require either
+        enabled "type_all_string" or second argument with supplied JSON
+        types. See Cpanel::JSON::XS::Type. When "type_all_string" is not
+        enabled or second argument is not provided (or is undef), then
+        "encode" croaks. It also croaks when the type for provided structure
+        in "encode" is incomplete.
+
+    $json = $json->type_all_string ([$enable])
+    $enable = $json->get_type_all_string
+             $json = $json->type_all_string([$enable])
+
+        If $enable is true (or missing), then "encode" will always produce
+        stable deterministic JSON string types in resulted output.
+
+        When $enable is false, then result of encoded JSON output may be
+        different for different Perl versions and may depends on loaded
+        modules.
+
+        This is useful it you need deterministic JSON types, independently
+        of used Perl version and other modules, but do not want to write
+        complicated type definitions for Cpanel::JSON::XS::Type.
 
     $json = $json->allow_dupkeys ([$enable])
     $enabled = $json->get_allow_dupkeys
@@ -1417,6 +1433,9 @@ MAPPING
 
         If you want to have stable and deterministic types in JSON encoder
         then use Cpanel::JSON::XS::Type.
+
+        Alternative way for deterministic types is to use "type_all_string"
+        method when all perl scalars are encoded to JSON strings.
 
         Non-deterministic behavior is following: scalars that have last been
         used in a string context before encoding as JSON strings, and

--- a/XS.pm
+++ b/XS.pm
@@ -839,10 +839,27 @@ encoders.  So it is not recommended to use it.
      $json = $json->require_types([$enable])
 
 If C<$enable> is true (or missing), then C<encode> will require
-second argument with supplied JSON types. See L<Cpanel::JSON::XS::Type>.
-When second argument is not provided (or is undef), then C<encode>
+either enabled C<type_all_string> or second argument with supplied JSON types.
+See L<Cpanel::JSON::XS::Type>. When C<type_all_string> is not enabled or
+second argument is not provided (or is undef), then C<encode>
 croaks. It also croaks when the type for provided structure in
 C<encode> is incomplete.
+
+=item $json = $json->type_all_string ([$enable])
+
+=item $enable = $json->get_type_all_string
+
+     $json = $json->type_all_string([$enable])
+
+If C<$enable> is true (or missing), then C<encode> will always
+produce stable deterministic JSON string types in resulted output.
+
+When C<$enable> is false, then result of encoded JSON output may be
+different for different Perl versions and may depends on loaded modules.
+
+This is useful it you need deterministic JSON types, independently of used
+Perl version and other modules, but do not want to write complicated type
+definitions for L<Cpanel::JSON::XS::Type>.
 
 =item $json = $json->allow_dupkeys ([$enable])
 
@@ -1589,6 +1606,9 @@ changed by Perl version or any other loaded Perl module.
 
 If you want to have stable and deterministic types in JSON encoder then
 use L<Cpanel::JSON::XS::Type>.
+
+Alternative way for deterministic types is to use C<type_all_string>
+method when all perl scalars are encoded to JSON strings.
 
 Non-deterministic behavior is following: scalars that have last been
 used in a string context before encoding as JSON strings, and anything

--- a/XS.xs
+++ b/XS.xs
@@ -1059,8 +1059,6 @@ encode_av (pTHX_ enc_t *enc, AV *av, SV *typesv)
   if (enc->indent >= enc->json.max_depth)
     croak (ERR_NESTING_EXCEEDED);
 
-  SvGETMAGIC (typesv);
-
   if (UNLIKELY (SvOK (typesv)))
     {
       if (SvROK (typesv) &&
@@ -1219,8 +1217,6 @@ encode_hv (pTHX_ enc_t *enc, HV *hv, SV *typesv)
 
   if (enc->indent >= enc->json.max_depth)
     croak (ERR_NESTING_EXCEEDED);
-
-  SvGETMAGIC (typesv);
 
   if (UNLIKELY (SvOK (typesv)))
     {
@@ -1775,6 +1771,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
   int force_conversion = 0;
 
   SvGETMAGIC (sv);
+  SvGETMAGIC (typesv);
 
   if (UNLIKELY (!(SvOK (typesv)) && (enc->json.flags & F_REQUIRE_TYPES)))
     croak ("type for '%s' was not specified", SvPV_nolen (sv));
@@ -1793,8 +1790,6 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
           return;
         }
     }
-
-  SvGETMAGIC (typesv);
 
   if (UNLIKELY (SvOK (typesv)))
     {

--- a/XS/Type.pm
+++ b/XS/Type.pm
@@ -174,6 +174,12 @@ JSON encoder chooses one that matches.
 Like L<C<json_type_anyof>|/json_type_anyof>, but scalar can be only
 perl's C<undef>.
 
+=back
+
+=head2 Recursive specifications
+
+=over 4
+
 =item json_type_weaken
 
 This function can be used as an argument for L</json_type_arrayof>,
@@ -190,6 +196,25 @@ See following example:
       json_type_weaken($struct),
       json_type_arrayof(JSON_TYPE_STRING),
   );
+
+If you want to encode all perl scalars to JSON string types despite
+how complicated is input perl structure you can define JSON type
+specification for alternatives recursively. It could be defined as:
+
+  my $type = json_type_anyof();
+  $type->[0] = JSON_TYPE_STRING_OR_NULL;
+  $type->[1] = json_type_arrayof(json_type_weaken($type));
+  $type->[2] = json_type_hashof(json_type_weaken($type));
+
+  print encode_json([ 10, "10", { key => 10 } ], $type);
+  # ["10","10",{"key":"10"}]
+
+An alternative solution for encoding all scalars to JSON strings is to
+use C<type_all_string> method of L<Cpanel::JSON::XS> itself:
+
+  my $json = Cpanel::JSON::XS->new->type_all_string;
+  print $json->encode([ 10, "10", { key => 10 } ]);
+  # ["10","10",{"key":"10"}]
 
 =back
 

--- a/t/120_type_all_string.t
+++ b/t/120_type_all_string.t
@@ -1,0 +1,14 @@
+use strict;
+use warnings;
+
+use Cpanel::JSON::XS;
+
+use Test::More tests => 5;
+
+my $sjson = Cpanel::JSON::XS->new->canonical->require_types->type_all_string->allow_nonref;
+
+is($sjson->encode(0), '"0"');
+is($sjson->encode("0"), '"0"');
+is($sjson->encode(0.5), '"0.5"');
+is($sjson->encode("0.5"), '"0.5"');
+is($sjson->encode([ 1, "2", { key1 => 3.5 }, [ "string", -10 ] ]), '["1","2",{"key1":"3.5"},["string","-10"]]');


### PR DESCRIPTION
When type_all_string is set then encode method produce stable deterministic
string types in result JSON.

This can be an alternative to Cpanel::JSON::XS::Type when having
deterministic output is required but string JSON types are enough for any
output.