### PR TITLE
t/54_stringify.t fails if older JSON installed

### DIFF
--- a/t/54_stringify.t
+++ b/t/54_stringify.t
@@ -3,13 +3,11 @@ use strict;
 use warnings;
 use Test::More;
 BEGIN {
-  eval "require Time::Piece;";
-  if ($@) {
-    plan skip_all => "Time::Piece required";
-    exit 0;
-  }
-  eval 'require JSON;'
-    or plan skip_all => 'JSON required for cross testing';
+  eval 'use Time::Piece (); 1'
+    or plan skip_all => "Time::Piece required";
+  # allow_unknown method added to JSON in 2.09
+  eval 'use JSON 2.09 (); 1'
+    or plan skip_all => 'JSON 2.09 required for cross testing';
   $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }
 use Time::Piece;


### PR DESCRIPTION
The allow_unknown method was added to JSON in version 2.09.  If you have an older version of JSON.pm installed, t/54_stringify.t fails.

I changed the prerequisite check to skip the test unless the version of JSON is at least 2.09.  This was based on the similar test in t/20_unknown.t.

I changed the check for Time::Piece just to be consistent.  It worked ok, but it was 5 lines of code when it only needed 2.