### PR TITLE
List::MoreUtils is no longer an upstream test prereq

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -126,7 +126,6 @@ WriteMakefile(
             'Test::CheckChanges'   => '1.14',
             'Class::XSAccessor'    => 0,
             'Text::CSV_XS'         => 0,
-            'List::MoreUtils'      => 0,
             'Test::Kwalitee'       => 0,
           }
         }

--- a/xt/kwalitee.t
+++ b/xt/kwalitee.t
@@ -12,7 +12,7 @@ plan skip_all => 'This test is only run for the module author'
 
 # Missing XS dependencies are usually not caught by EUMM
 # And they are usually only XS-loaded by the importer, not require.
-for (qw( Class::XSAccessor Text::CSV_XS List::MoreUtils )) {
+for (qw( Class::XSAccessor Text::CSV_XS )) {
   eval "use $_;";
   plan skip_all => "$_ required for Test::Kwalitee"
     if $@;


### PR DESCRIPTION
It was remoed as a prereq of Module::CPANTS::Analyse in version 0.88 (2013).