### PR TITLE
adjust t/20_unknown.t pp bool tests for native bool when supported

### DIFF
--- a/t/20_unknown.t
+++ b/t/20_unknown.t
@@ -49,15 +49,15 @@ is( $pp->encode( {null => \"some"} ),   '{"null":null}',   'pp unknown' );
 is( $pp->encode( {null => \""} ),       '{"null":null}',   'pp unknown' );
 # valid special yes/no values even without nonref
 my $e = $pp->encode( {true => !!1} ); # pp is a bit inconsistent
-#if ($JSON::PP::VERSION ne '4.08') {
-ok( ($e eq '{"true":"1"}') || ($e eq  '{"true":1}'),     'pp sv_yes' );
-is( $pp->encode( {false => !!0} ),    '{"false":""}',    'pp sv_no' );
-is( $pp->encode( {false => !!""} ),   '{"false":""}',    'pp sv_no' );
-#} else { # surprisingly using native bool (unblessed) overloads. GH #194
-#  is( $pp->encode( {true => !!1} ),     '{"true":true}',   'pp sv_yes' );
-#  is( $pp->encode( {false => !!0} ),    '{"false":false}', 'pp sv_no' );
-#  is( $pp->encode( {false => !!""} ),   '{"false":false}', 'pp sv_no' );
-#}
+if (JSON::PP->can('CORE_BOOL') && JSON::PP::CORE_BOOL()) {  # native bool
+  is( $pp->encode( {true => !!1} ),       '{"true":true}',   'pp sv_yes' );
+  is( $pp->encode( {false => !!0} ),      '{"false":false}', 'pp sv_no' );
+  is( $pp->encode( {false => !!""} ),     '{"false":false}', 'pp sv_no' );
+} else {
+  ok( ($e eq '{"true":"1"}') || ($e eq '{"true":1}'),        'pp sv_yes' );
+  is( $pp->encode( {false => !!0} ),      '{"false":""}',    'pp sv_no' );
+  is( $pp->encode( {false => !!""} ),     '{"false":""}',    'pp sv_no' );
+}
 is( $pp->encode( {true => \!!1} ),      '{"true":true}',   'pp \sv_yes');
 is( $pp->encode( {false => \!!0} ),     '{"false":null}',  'pp \sv_no' );
 is( $pp->encode( {false => \!!""} ),    '{"false":null}',  'pp \sv_no' );


### PR DESCRIPTION
Newer perl versions can recognize perl's native boolean values,
including when copied. New versions of JSON::PP are intended to be able
to encode these values as true/false rather than 1/"" like before. This
requires both a new perl version (5.36+) and a new JSON::PP version.
JSON::PP versions that support this will define the CORE_BOOL constant,
and it will be true when they are able to recognize the boolean values.

Adjust the boolean tests in t/20_unknown.t to account for this new
encoding by checking the CORE_BOOL constant.

Fixes #198