### PR TITLE
remove overloads before re-adding them to silence warnings

### DIFF
--- a/XS.pm
+++ b/XS.pm
@@ -2340,6 +2340,7 @@ BEGIN {
   local $^W; # silence redefine warnings. no warnings 'redefine' does not help
   # These already come with JSON::PP::Boolean. Avoid redefine warning.
   if (!defined $JSON::PP::Boolean::VERSION or $JSON::PP::VERSION lt '4.00') {
+    &overload::unimport( 'overload', '0+', '++', '--' );
     &overload::import( 'overload',
                        "0+"     => sub { ${$_[0]} },
                        "++"     => sub { $_[0] = ${$_[0]} + 1 },
@@ -2347,6 +2348,7 @@ BEGIN {
       );
   }
   # workaround 5.6 reserved keyword warning
+  &overload::unimport( 'overload', '""', 'eq', 'ne' );
   &overload::import( 'overload',
     '""'     => sub { ${$_[0]} == 1 ? '1' : '0' }, # GH 29
     'eq'     => sub {


### PR DESCRIPTION
To prevent warnings from redefining overloads on JSON::PP::Boolean, the code is setting $^W to 0. This has classically worked because overload.pm did not enable or disable warnings. This is not something that should be relied on.

Rather than rely on $^W, just remove the overloads we are expecting to overwrite using overload->unimport.