### PR TITLE
Allow \' in strings when allow_singlequote is enabled

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -3377,7 +3377,16 @@ _decode_str (pTHX_ dec_t *dec, char endstr)
                   case 'n': ++dec_cur; *cur++ = '\012'; break;
                   case 'f': ++dec_cur; *cur++ = '\014'; break;
                   case 'r': ++dec_cur; *cur++ = '\015'; break;
-
+                  case '\'':
+                    {
+                      if( dec->json.flags & F_ALLOW_SQUOTE ) {
+                        *cur++ = *dec_cur++;
+                      } else {
+                        --dec_cur;
+                        ERR ("illegal backslash escape sequence in string");
+                      }
+                      break;
+                    }
                   case 'x':
 		    {
 		      UV c;

--- a/t/107_allow_singlequote.t
+++ b/t/107_allow_singlequote.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 8;
+use Test::More tests => 10;
 use strict;
 use Cpanel::JSON::XS;
 #########################
@@ -10,6 +10,9 @@ eval q| $json->decode("{'foo':'bar'}") |;
 ok($@, "error $@"); # in XS and PP, the error message differs.
 # '"' expected, at character offset 1 (before "'foo':'bar'}")
 
+eval q| $json->decode(qq[{"foo":'"ba\'r"}]) |;
+ok($@, "error $@");
+
 $json->allow_singlequote;
 
 is($json->decode(q|{'foo':"bar"}|)->{foo}, 'bar');
@@ -17,6 +20,8 @@ is($json->decode(q|{'foo':'bar'}|)->{foo}, 'bar');
 is($json->allow_barekey->decode(q|{foo:'bar'}|)->{foo}, 'bar');
 
 is($json->decode(q|{'foo baz':'bar'}|)->{"foo baz"}, 'bar');
+
+is($json->decode(q|{'foo baz':'ba\'r'}|)->{"foo baz"}, q[ba'r]);
 
 # GH 54 from Locale::Wolowitz
 is($json->decode(q|{xo:"how's it hangin 1"}|)->{"xo"}, q(how's it hangin 1));


### PR DESCRIPTION
This is attempting to fix #216

Could have been more elegantly solved with a case fallthrough, but I did not want to introduce that due to fragility for future code changes.
