### PR TITLE
fix NAN/INF for AIX (Tux: AIX-5.3, tested by XSven on AIX-7.3) GH #165

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for Perl extension Cpanel::JSON::XS
 
 TODO: http://stevehanov.ca/blog/index.php?id=104 compression
 
+4.37 ...
+	- fix NAN/INF for AIX (Tux: AIX-5.3, tested by XSven on AIX-7.3) GH #165
+
 4.36 2023-03-02 (rurban)
         - remove the SAVESTACK_POS noop. Merged from JSON-XS-3.02,
           removed there with 4.0. requested to remove with

--- a/XS.xs
+++ b/XS.xs
@@ -88,15 +88,17 @@
 #define HAVE_NEG_NAN
 #define STR_NEG_INF "---"
 #define STR_NEG_NAN "?"
-#elif defined(_AIX)
+#elif defined(_AIX) || defined(_AIX50)
 /* xlC compiler: __TOS_AIX__ FIXME: This does not work yet. GH #165 */
-#define STR_INF "INF.0"
-#define STR_INF2 "-INF.0"
+#define STR_INF "INF"
+#define STR_INF2 "INF.0"
+#define HAVE_NEG_NAN
+#define STR_NEG_INF "-INF"
 #define HAVE_NEG_NAN
 #define HAVE_QNAN
 #define STR_NAN "NaN"
-//#define STR_QNAN "NaNQ"
-#define STR_QNAN "NANQ"
+#define STR_QNAN "NaNQ"
+//#define STR_QNAN "NANQ"
 #else
 #define STR_INF "inf"
 #define STR_NAN "nan"
@@ -2219,6 +2221,9 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
             }
 #endif
 
+/* #if defined(_AIX) || defined(_AIX50)
+ * (void)fprintf (stderr, "#|# >%s<\n", enc->cur);
+ * #endif */
 #ifdef STR_INF4
           if (UNLIKELY(strEQc(enc->cur, STR_INF)
                        || strEQc(enc->cur, STR_INF2)
@@ -2236,6 +2241,13 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
             inf_or_nan = 2;
           else if (UNLIKELY(strEQc(enc->cur, STR_NEG_NAN)))
             inf_or_nan = 3;
+#endif
+#if defined(_AIX) || defined(_AIX50)
+          else if (UNLIKELY(strEQc(enc->cur, STR_INF)
+                         || strEQc(enc->cur, STR_INF2)))
+            inf_or_nan = 1;
+          else if (UNLIKELY(strEQc(enc->cur, STR_NEG_INF)))
+            inf_or_nan = 2;
 #endif
           else if
 #ifdef HAVE_QNAN

--- a/t/117_numbers.t
+++ b/t/117_numbers.t
@@ -21,7 +21,7 @@ my (@inf, @neg_inf, @nan, @neg_nan);
 my ($inf, $nan) =
   ($^O eq 'MSWin32') ? ('1.#INF','1.#QNAN') :
   ($^O eq 'solaris') ? ('Infinity','NaN') :
-  ($^O eq 'aix')     ? ('inf','NANQ') :
+  ($^O eq 'aix')     ? ('INF','NaNQ') :
   ($^O eq 'hpux')    ? ('++','-?') :
                        ('inf','nan');
 my $neg_nan =


### PR DESCRIPTION
This was tested on
```
AIX 5.3.0.0/TL12-05/RD1140/64
IBM 9115 System p5 505 PowerPC

This is perl 5, version 14, subversion 2 (v5.14.2) built for aix-64all

  vac.C                    12.1.0.12  COMMITTED  IBM XL C Compiler
```
and verified by @XSven for `AIX/7300-01-02-2320` (they did not mention the compiler)

I won't guarantee that the patch could be simplified more than this. I left in the comment, as that helped me find the correct approach