### PR TITLE
Encode real core booleans as boolean notation (Fixes #214)

### DIFF
--- a/t/20_unknown.t
+++ b/t/20_unknown.t
@@ -7,6 +7,7 @@ BEGIN {
     or plan skip_all => 'JSON::PP 2.09 required for cross testing';
   $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }
+use constant HAVE_BOOLEANS => ($^V ge v5.36);
 plan tests => 32;
 use JSON::PP ();
 use Cpanel::JSON::XS ();
@@ -64,9 +65,16 @@ is( $pp->encode( {false => \!!""} ),    '{"false":null}',  'pp \sv_no' );
 
 is( $json->encode( {null => \"some"} ), '{"null":null}',   'js unknown' );
 is( $json->encode( {null => \""} ),     '{"null":null}',   'js unknown' );
-is( $json->encode( {true => !!1} ),     '{"true":1}',      'js sv_yes' );
-is( $json->encode( {false => !!0} ),    '{"false":""}',    'js sv_no' );
-is( $json->encode( {false => !!""} ),   '{"false":""}',    'js sv_no' );
+if(HAVE_BOOLEANS) {
+   is( $json->encode( {true => !!1} ),     '{"true":true}',   'js sv_yes' );
+   is( $json->encode( {false => !!0} ),    '{"false":false}', 'js sv_no' );
+   is( $json->encode( {false => !!""} ),   '{"false":false}', 'js sv_no' );
+}
+else {
+   is( $json->encode( {true => !!1} ),     '{"true":1}',      'js sv_yes' );
+   is( $json->encode( {false => !!0} ),    '{"false":""}',    'js sv_no' );
+   is( $json->encode( {false => !!""} ),   '{"false":""}',    'js sv_no' );
+}
 is( $json->encode( {true => \!!1} ),    '{"true":true}',   'js \sv_yes' );
 is( $json->encode( {false => \!!0} ),   '{"false":null}',  'js \sv_no' );
 is( $json->encode( {false => \!!""} ),  '{"false":null}',  'js \sv_no' );

--- a/t/25_boolean.t
+++ b/t/25_boolean.t
@@ -1,5 +1,6 @@
 use strict;
-use Test::More tests => 42;
+use constant HAVE_BOOLEANS => ($^V ge v5.36);
+use Test::More tests => 42 + (HAVE_BOOLEANS ? 2 : 0);
 use Cpanel::JSON::XS ();
 use Config;
 
@@ -125,3 +126,11 @@ is($cjson->encode(do { my $struct = $unblessed_bool_cjson->decode($truefalse, my
 $js = $unblessed_bool_cjson->decode($truefalse);
 ok eval { $js->[0] = "new value 0" }, "decoded 'true' is modifiable" or diag($@);
 ok eval { $js->[1] = "new value 1" }, "decoded 'false' is modifiable" or diag($@);
+
+if(HAVE_BOOLEANS) {
+  no if HAVE_BOOLEANS, warnings => "experimental::builtin";
+  is($cjson->encode({t => builtin::true}), q({"t":true}),
+    'true core booleans encode as boolean');
+  is($cjson->encode({f => builtin::false}), q({"f":false}),
+    'false core booleans encode as boolean');
+}

--- a/t/96_mojo.t
+++ b/t/96_mojo.t
@@ -9,7 +9,7 @@ BEGIN {
     plan skip_all => "Mojo::JSON::decode_json required for testing interop";
     exit 0;
   }
-  plan tests => 9;
+  plan tests => 12;
 }
 
 use Mojo::JSON ();
@@ -35,18 +35,10 @@ ok( !$js->{is_false}, 'ok !false');
 my $mj = Mojo::JSON::encode_json( $yesno );
 $js = $cjson->decode( $mj );
 
-# fragile
-ok( $js->[0] eq '' or $js->[0] == 0 or !$js->[0], 'can decode Mojo false' );
-is( $js->[1], 1,  'can decode Mojo true' );
-# Note this is fragile. it depends on the internal representation of booleans.
-# It can also be ['0', '1']
-if ($js->[0] eq '') {
-  is_deeply( $js, ['', 1], 'can decode Mojo booleans' )
-    or diag( $mj, $js );
-} else {
- TODO: {
-    local $TODO = 'fragile false => "0"';
-    is_deeply( $js, ['', 1], 'can decode Mojo booleans' )
-      or diag( $mj, $js );
-  }
-}
+ok( !$js->[0], 'decoded Mojo false is false' );
+ok( $js->[0] == 0, 'decoded Mojo false is zero' );
+ok( $js->[0] eq "", 'decoded Mojo false is empty string' );
+
+ok( $js->[1], 'decoded Mojo true is true' );
+ok( $js->[1] == 1, 'decoded Mojo true is one' );
+ok( $js->[1] eq "1", 'decoded Mojo true is "1" string' );


### PR DESCRIPTION
A fix for #214.

This PR isn't complete yet though because it causes some other tests related to boolean serialisation to now fail. You'll have to decide if you want to change those tests, or make this behaviour now optional on some configuration flag or somesuch, in order to avoid that.