### PR TITLE
Disallow -W-format warnings for MS Windows only.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,10 @@ if ($Config{gccversion} and $Config{gccversion} =~ /^(\d+\.\d+)\./) {
   } elsif ($gccver >= 3.4) {
     $define = '-Wall -Wdeclaration-after-statement -Wextra -W';
   }
+
+  # -Wformat does not support the Windows specific "%I64u" format
+  # and will cause false warnings in compiling 'encode_sv'.
+  if($define && $^O =~/MSWin32/i) { $define .= ' -Wno-format' }
 }
 if ($] < 5.022 && $Config{d_setlocale} && $Config{usethreads}) {
   if (-e "/usr/include/xlocale.h") {


### PR DESCRIPTION
GCC doesn't support Windows specific "%I64u" format, and false warnings will be emitted on Windows during compilation (in <code>encode_sv()</code>, in XS.xs) if <code>[-Wformat=]</code> is enabled.

Therefore, we specify " -Wno-format" (for Windows only) in the Makefile.PL.