### PR TITLE
Restructured handling of Win32 quadmath.

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -2153,20 +2153,20 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
           if (force_conversion)
             {
               had_nokp = 0;
-#if defined(USE_QUADMATH) && defined(HAVE_ISINFL)
-              if (UNLIKELY(isinfl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isinf */
+              if (UNLIKELY(Perl_isinf(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isinfq */
-              if (UNLIKELY(isinfq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISINFL)
+              if (UNLIKELY(isinfl(nv)))
 #else
               if (UNLIKELY(isinf(nv)))
 #endif
                 nv = (nv > 0) ? NV_MAX : -NV_MAX;
-#if defined(USE_QUADMATH) && defined(HAVE_ISNANL)
-              if (UNLIKELY(isnanl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isnan */
+              if (UNLIKELY(Perl_isnan(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isnanq */
-              if (UNLIKELY(isnanq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISNANL)
+              if (UNLIKELY(isnanl(nv)))
 #else
               if (UNLIKELY(isnan(nv)))
 #endif
@@ -2175,11 +2175,11 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
           /* With no stringify_infnan we can skip the conversion, returning null. */
           else if (enc->json.infnan_mode == 0)
             {
-#if defined(USE_QUADMATH) && defined(HAVE_ISINFL)
-              if (UNLIKELY(isinfl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isinf */
+              if (UNLIKELY(Perl_isinf(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isinfq */
-              if (UNLIKELY(isinfq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISINFL)
+              if (UNLIKELY(isinfl(nv)))
 #else
               if (UNLIKELY(isinf(nv)))
 #endif
@@ -2187,11 +2187,11 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
                   inf_or_nan = (nv > 0) ? 1 : 2;
                   goto is_inf_or_nan;
                 }
-#if defined(USE_QUADMATH) && defined(HAVE_ISNANL)
-              if (UNLIKELY(isnanl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isnan */
+              if (UNLIKELY(Perl_isnan(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isnanq */
-              if (UNLIKELY(isnanq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISNANL)
+              if (UNLIKELY(isnanl(nv)))
 #else
               if (UNLIKELY(isnan(nv)))
 #endif
@@ -2588,11 +2588,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
         {
 #if PERL_VERSION < 8
 /* SvIV() and SvUV() in Perl 5.6 does not handle Inf and NaN in NV slot */
-# if defined(USE_QUADMATH) && defined(HAVE_ISINFL) && defined(HAVE_ISNANL)
-          if (SvNOKp (sv) && UNLIKELY (isinfl (SvNVX (sv))))
-# else
           if (SvNOKp (sv) && UNLIKELY (isinf (SvNVX (sv))))
-# endif
             {
               if (SvNVX (sv) < 0)
                 {
@@ -2606,11 +2602,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
                   iv = (IV)uv;
                 }
             }
-# if defined(USE_QUADMATH) && defined(HAVE_ISINFL) && defined(HAVE_ISNANL)
-          else if (!SvNOKp (sv) || LIKELY (!isnanl (SvNVX (sv))))
-# else
           else if (!SvNOKp (sv) || LIKELY (!isnan (SvNVX (sv))))
-# endif
 #endif
             sv_to_ivuv (aTHX_ sv, &is_neg, &iv, &uv);
         }


### PR DESCRIPTION
https://github.com/rurban/Cpanel-JSON-XS/pull/229 from a couple of days ago depended upon the (preprocessing) conditions <code>defined(USE_QUADMATH) && defined(HAVE_ISINFL)</code> and <code>defined(USE_QUADMATH) && defined(HAVE_ISNANL)</code> being FALSE.
If either of those conditions were ever altered such that they became TRUE, then Windows quadmath builds of Cpanel::JSON::XS
would be broken again.
This restructuring avoids that dependency. It no longer matters to Windows quadmath builds whether those conditions are TRUE or FALSE.

Tony Cook suggested to me that the preprocessing should do away with the isnan/isnanl and isinf/isinfl calls and just use Perl_isnan and Perl_isinf.
That would be preferable but, when I tried it out, I found some tests failed on older perls; 5.10.0 and 5.20.3 are 2 such perls.
Since Cpanel::JSON::XS apparently wants to support those perls, I gave that idea away - but I do now use <code>Perl_isnan</code> and <code>Perl_isinf</code> in the code that's specific to Windows quadmath builds. 
(Quadmath builds on Windows became available in 5.32, so we don't have to worry about broken Perl_isnan or broken Perl_isinf.)

I had also considered replacing HAVE_ISINFL/HAVE_ISNANL calls with HAS_ISINFL/HAS_ISNANL because I believed the former to be always undefined.
But if that belief is correct, then such a change would alter the way the code runs - and perhaps thereby cause a breakage.
Also, I noticed that sqlite3.c in DBD-SQLite checks on the symbol <code>HAVE_ISNAN</code> .... so maybe these HAVE_* variants can sometimes be defined, after all (?).
Others are free to go down that path if they wish, but I think I'll go with the "aint broken, don't fix it" approach in this instance.

I have, however, removed some "dead" preprocessing code that was checking whether USE_QUADMATH was defined whilst inside a block that was only entered if PERL_VERSION was less than 8.
USE_QUADMATH cannot be defined by perl prior to PERL_VERSION 22.
