### PR TITLE
Remove non-character warnings (Fixes GH #227)

### DIFF
--- a/README
+++ b/README
@@ -280,10 +280,11 @@ A FEW NOTES ON UNICODE AND PERL
 
     5. A string containing "high" (> 255) character values is *not* a UTF-8
     string.
-    6. Unicode noncharacters only warn, as in core.
+    6. Raw non-Unicode characters below U+10FFFF are allowed.
         The 66 Unicode noncharacters U+FDD0..U+FDEF, and U+*FFFE, U+*FFFF
-        just warn, see <http://www.unicode.org/versions/corrigendum9.html>.
-        But illegal surrogate pairs fail to parse.
+        are allowed without warning, as JSON::PP does, see
+        <http://www.unicode.org/versions/corrigendum9.html>. But illegal
+        surrogate pairs fail to parse.
 
     7. Raw non-Unicode characters above U+10FFFF are disallowed.
         Raw non-Unicode characters outside the valid unicode range fail to
@@ -1801,11 +1802,6 @@ ENCODING/CODESET FLAG NOTES
 
     This works because "__proto__" is not valid outside of strings, so every
     occurrence of ""__proto__"\s*:" must be a string used as property name.
-
-    Unicode non-characters between U+FFFD and U+10FFFF are decoded either to
-    the recommended U+FFFD REPLACEMENT CHARACTER (see Unicode PR #121:
-    Recommended Practice for Replacement Characters), or in the binary or
-    relaxed mode left as is, keeping the illegal non-characters as before.
 
     Raw non-Unicode characters outside the valid unicode range fail now to
     parse, because "A string is a sequence of zero or more Unicode

--- a/XS.pm
+++ b/XS.pm
@@ -347,11 +347,12 @@ a Unicode string encoded in UTF-8, giving you a binary string.
 =item 5. A string containing "high" (> 255) character values is I<not>
 a UTF-8 string.
 
-=item 6. Unicode noncharacters only warn, as in core.
+=item 6. Raw non-Unicode characters below U+10FFFF are allowed.
 
-The 66 Unicode noncharacters U+FDD0..U+FDEF, and U+*FFFE, U+*FFFF just
-warn, see L<http://www.unicode.org/versions/corrigendum9.html>.  But
-illegal surrogate pairs fail to parse.
+The 66 Unicode noncharacters U+FDD0..U+FDEF, and U+*FFFE, U+*FFFF are
+allowed without warning, as JSON::PP does, see
+L<http://www.unicode.org/versions/corrigendum9.html>.  But illegal
+surrogate pairs fail to parse.
 
 =item 7. Raw non-Unicode characters above U+10FFFF are disallowed.
 
@@ -1989,11 +1990,6 @@ output for these property strings, e.g.:
 
 This works because C<__proto__> is not valid outside of strings, so every
 occurrence of C<"__proto__"\s*:> must be a string used as property name.
-
-Unicode non-characters between U+FFFD and U+10FFFF are decoded either
-to the recommended U+FFFD REPLACEMENT CHARACTER (see Unicode PR #121:
-Recommended Practice for Replacement Characters), or in the binary or
-relaxed mode left as is, keeping the illegal non-characters as before.
 
 Raw non-Unicode characters outside the valid unicode range fail now to
 parse, because "A string is a sequence of zero or more Unicode

--- a/XS.xs
+++ b/XS.xs
@@ -242,6 +242,7 @@ mingw_modfl(long double x, long double *ip)
 #ifndef HvNAMEUTF8
 # define HvNAMEUTF8(hv) 0
 #endif
+#if 0
 /* since 5.14 check use warnings 'nonchar' */
 #ifdef WARN_NONCHAR
 #define WARNER_NONCHAR(hi)                                      \
@@ -258,6 +259,9 @@ mingw_modfl(long double x, long double *ip)
 #define WARNER_NONCHAR(hi)                                         \
   Perl_warner(aTHX_ packWARN(WARN_UTF8),                           \
               "Unicode non-character U+%04lX is illegal", (unsigned long)hi)
+#endif
+#else
+#define WARNER_NONCHAR(hi)
 #endif
 
 /* since 5.16 */
@@ -3513,15 +3517,6 @@ _decode_str (pTHX_ dec_t *dec, char endstr)
    The WG's consensus was to leave the full range present
    in the ABNF and add the interoperability guidance about
    values outside the Unicode accepted range.
-
-   http://seriot.ch/parsing_json.html#25 According to the Unicode
-   standard, illformed subsequences should be replaced by U+FFFD
-   REPLACEMENT CHARACTER. (See Unicode PR #121: Recommended Practice
-   for Replacement Characters). Several parsers use replacement
-   characters, while other keep the escaped form or produce an
-   non-Unicode character (see Section 5 - Parsing Contents).  This
-   values are not for interchange, only for application internal use.
-   They are different from private use.  Most parsers accept these.
 */
                           if (UNLIKELY(
                                  !(dec->json.flags & F_RELAXED)

--- a/t/01_utf8.t
+++ b/t/01_utf8.t
@@ -1,4 +1,4 @@
-use Test::More tests => 162;
+use Test::More tests => 152;
 use utf8;
 use Cpanel::JSON::XS;
 use warnings;
@@ -42,56 +42,6 @@ SKIP: {
 
 # TODO: test utf8 hash keys,
 # test utf8 strings without any char > 0x80.
-
-# warn on the 66 non-characters as in core
-{
-  BEGIN { 'warnings'->import($] < 5.014 ? 'utf8' : 'nonchar') }
-  my $w = '';
-  $SIG{__WARN__} = sub { $w = shift };
-  my $d = Cpanel::JSON::XS->new->allow_nonref->decode('"\ufdd0"');
-  my $warn = $w;
-  {
-    no warnings 'utf8';
-    is ($d, "\x{fdd0}", substr($warn,0,31)."...");
-  }
-  like ($warn, qr/^Unicode non-character U\+FDD0 is/);
-  $w = '';
-  # higher planes
-  $d = Cpanel::JSON::XS->new->allow_nonref->decode('"\ud83f\udfff"');
-  $warn = $w;
-  {
-    no warnings 'utf8';
-    is ($d, "\x{1ffff}", substr($warn,0,31)."...");
-  }
-  like ($w, qr/^Unicode non-character U\+1FFFF is/);
-  $w = '';
-  $d = Cpanel::JSON::XS->new->allow_nonref->decode('"\ud87f\udffe"');
-  $warn = $w;
-  {
-    no warnings 'utf8';
-    is ($d, "\x{2fffe}", substr($warn,0,31)."...");
-  }
-  like ($w, qr/^Unicode non-character U\+2FFFE is/);
-
-  $w = '';
-  $d = Cpanel::JSON::XS->new->allow_nonref->decode('"\ud8a4\uddd1"');
-  $warn = $w;
-  is ($d, "\x{391d1}", substr($warn,0,31)."...");
-  is ($w, '');
-}
-{
-  my $w;
-  BEGIN { 'warnings'->import($] < 5.014 ? 'utf8' : 'nonchar') }
-  $SIG{__WARN__} = sub { $w = shift };
-  # no warning with relaxed
-  my $d = Cpanel::JSON::XS->new->allow_nonref->relaxed->decode('"\ufdd0"');
-  my $warn = $w;
-  {
-    no warnings 'utf8';
-    is ($d, "\x{fdd0}", "no warning with relaxed");
-  }
-  is($w, undef);
-}
 
 # security exploits via ill-formed subsequences
 # see http://unicode.org/reports/tr36/#UTF-8_Exploit

--- a/t/30_jsonspec.t
+++ b/t/30_jsonspec.t
@@ -1,6 +1,6 @@
 # regressions and differences from the JSON Specs and JSON::PP
 # detected by http://seriot.ch/json/parsing.html
-use Test::More ($] >= 5.008) ? (tests => 686) : (skip_all => "needs 5.8");
+use Test::More ($] >= 5.008) ? (tests => 678) : (skip_all => "needs 5.8");
 use Cpanel::JSON::XS;
 BEGIN {
   require Encode if $] >= 5.008 && $] < 5.020; # Currently required for <5.20
@@ -107,32 +107,16 @@ sub i_undefined {
 sub i_pass {
   my ($str, $name) = @_;
   $@ = '';
-  my $w;
-  if ($name =~ /nonchar/) { # check the warning
-    require warnings;
-    warnings->import($] < 5.014 ? 'utf8' : 'nonchar');
-    $SIG{__WARN__} = sub { $w = shift };
-  }
   my $result = $todo{$name} ? eval { $json->decode($str) } : $json->decode($str);
-  my $warn = $w;
   TODO: {
     local $TODO = "$name" if exists $todo{$name};
     is($@, '', "no parsing error with undefined $name ".substr($@,0,40));
     isnt($result, undef, "valid result with undefined $name");
-    if ($name =~ /nonchar/) {
-      like ($warn, qr/^Unicode non-character U\+[10DFE]+ is/);
-      $w = '';
-    }
     $@ = '';
     #diag "$name $str";
     $result    = eval { $relaxed->decode($str) };
-    $warn = $w;
     is($@, '', "no parsing error with undefined $name relaxed ".substr($@,0,40));
     isnt($result, undef, "valid result with undefined $name relaxed");
-    if ($name =~ /nonchar/) {
-      is($warn, '');
-      $w = '';
-    }
   }
 }
 # result undefined, parsing failed


### PR DESCRIPTION
Aligns behavior with JSON::PP, no longer warns.