### PR TITLE
XS.xs - Restructure handling of Win32 quadmath.

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -2171,20 +2171,20 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
           if (force_conversion)
             {
               had_nokp = 0;
-#if defined(USE_QUADMATH) && defined(HAVE_ISINFL)
-              if (UNLIKELY(isinfl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isinf */
+              if (UNLIKELY(Perl_isinf(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isinfq */
-              if (UNLIKELY(isinfq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISINFL)
+              if (UNLIKELY(isinfl(nv)))
 #else
               if (UNLIKELY(isinf(nv)))
 #endif
                 nv = (nv > 0) ? NV_MAX : -NV_MAX;
-#if defined(USE_QUADMATH) && defined(HAVE_ISNANL)
-              if (UNLIKELY(isnanl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isnan */
+              if (UNLIKELY(Perl_isnan(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isnanq */
-              if (UNLIKELY(isnanq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISNANL)
+              if (UNLIKELY(isnanl(nv)))
 #else
               if (UNLIKELY(isnan(nv)))
 #endif
@@ -2193,11 +2193,11 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
           /* With no stringify_infnan we can skip the conversion, returning null. */
           else if (enc->json.infnan_mode == 0)
             {
-#if defined(USE_QUADMATH) && defined(HAVE_ISINFL)
-              if (UNLIKELY(isinfl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isinf */
+              if (UNLIKELY(Perl_isinf(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isinfq */
-              if (UNLIKELY(isinfq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISINFL)
+              if (UNLIKELY(isinfl(nv)))
 #else
               if (UNLIKELY(isinf(nv)))
 #endif
@@ -2205,11 +2205,11 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
                   inf_or_nan = (nv > 0) ? 1 : 2;
                   goto is_inf_or_nan;
                 }
-#if defined(USE_QUADMATH) && defined(HAVE_ISNANL)
-              if (UNLIKELY(isnanl(nv)))
+#if defined(USE_QUADMATH) && defined(WIN32) /* Use Perl_isnan */
+              if (UNLIKELY(Perl_isnan(nv)))
 
-#elif defined(USE_QUADMATH) && defined(WIN32) /* Safest to use isnanq */
-              if (UNLIKELY(isnanq(nv)))
+#elif defined(USE_QUADMATH) && defined(HAVE_ISNANL)
+              if (UNLIKELY(isnanl(nv)))
 #else
               if (UNLIKELY(isnan(nv)))
 #endif
@@ -2606,11 +2606,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
         {
 #if PERL_VERSION < 8
 /* SvIV() and SvUV() in Perl 5.6 does not handle Inf and NaN in NV slot */
-# if defined(USE_QUADMATH) && defined(HAVE_ISINFL) && defined(HAVE_ISNANL)
-          if (SvNOKp (sv) && UNLIKELY (isinfl (SvNVX (sv))))
-# else
           if (SvNOKp (sv) && UNLIKELY (isinf (SvNVX (sv))))
-# endif
             {
               if (SvNVX (sv) < 0)
                 {
@@ -2624,11 +2620,7 @@ encode_sv (pTHX_ enc_t *enc, SV *sv, SV *typesv)
                   iv = (IV)uv;
                 }
             }
-# if defined(USE_QUADMATH) && defined(HAVE_ISINFL) && defined(HAVE_ISNANL)
-          else if (!SvNOKp (sv) || LIKELY (!isnanl (SvNVX (sv))))
-# else
           else if (!SvNOKp (sv) || LIKELY (!isnan (SvNVX (sv))))
-# endif
 #endif
             sv_to_ivuv (aTHX_ sv, &is_neg, &iv, &uv);
         }


### PR DESCRIPTION
This replaces the closed https://github.com/rurban/Cpanel-JSON-XS/pull/230.
The elaboration contained in that closed PR is still pertinent to this PR - so please refer to it if you require further explanation.

BTW, I noticed that https://github.com/rurban/Cpanel-JSON-XS/pull/232 introduces the following compilation warning:
```
XS.xs: In function '_decode_str':
XS.xs:3462:29: warning: comparison is always false due to limited range of data type [-Wtype-limits]
 3462 |                       if (c == (char)-1)
      |                             ^~
```
With this PR, that line number changes from 3462 to 3454.

UPDATE:
What I'm seeing here is not what I expected
I don't know why the original PR is being included, and the "New changes since you last viewed" are showing alterations that I haven't made. 

Let me know if it's not usable - and I'll delete everything (including my fork of the repo) and start all over again.