### PR TITLE
Add test cases when type_all_string is active 

### DIFF
--- a/t/120_type_all_string.t
+++ b/t/120_type_all_string.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Cpanel::JSON::XS;
 
-use Test::More tests => 5;
+use Test::More tests => 7;
 
 my $sjson = Cpanel::JSON::XS->new->canonical->require_types->type_all_string->allow_nonref;
 
@@ -12,3 +12,5 @@ is($sjson->encode("0"), '"0"');
 is($sjson->encode(0.5), '"0.5"');
 is($sjson->encode("0.5"), '"0.5"');
 is($sjson->encode([ 1, "2", { key1 => 3.5 }, [ "string", -10 ] ]), '["1","2",{"key1":"3.5"},["string","-10"]]');
+is($sjson->encode([ Cpanel::JSON::XS::false, Cpanel::JSON::XS::true ]), '["false","true"]');
+is($sjson->encode([ 1 < 0, 1 > 0 ]), '["","1"]');

--- a/t/120_type_all_string.t
+++ b/t/120_type_all_string.t
@@ -3,7 +3,7 @@ use warnings;
 
 use Cpanel::JSON::XS;
 
-use Test::More tests => 7;
+use Test::More tests => 8;
 
 my $sjson = Cpanel::JSON::XS->new->canonical->require_types->type_all_string->allow_nonref;
 
@@ -14,3 +14,4 @@ is($sjson->encode("0.5"), '"0.5"');
 is($sjson->encode([ 1, "2", { key1 => 3.5 }, [ "string", -10 ] ]), '["1","2",{"key1":"3.5"},["string","-10"]]');
 is($sjson->encode([ Cpanel::JSON::XS::false, Cpanel::JSON::XS::true ]), '["false","true"]');
 is($sjson->encode([ 1 < 0, 1 > 0 ]), '["","1"]');
+is($sjson->encode(undef), 'null');


### PR DESCRIPTION
Show how booleans, boolean expressions, and undef are serialized when type_all_string is active.