### PR TITLE
fix heap-buffer-overflow read when constructing foreign class

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -5072,7 +5072,7 @@ void new (char *klass)
           if (!stash)
             croak ("Cannot create a %s object from an unblessed reference", klass);
         } else {
-          stash = strEQc (klass, "Cpanel::JSON::XS") ? JSON_STASH : gv_stashpv (klass, 1);
+          stash = strlen(klass) == 16 && strEQc (klass, "Cpanel::JSON::XS") ? JSON_STASH : gv_stashpv (klass, 1);
         }
         XPUSHs (sv_2mortal (sv_bless (
            newRV_noinc (pv), stash


### PR DESCRIPTION
It's possible to force new() to read past the end of provided `klass` name when constructing aliased/inherited object (in my case it was plain "JSON::XS"). Here's ASAN report:

```
==57344==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6040000ddd3a at pc 0x000105c35f98 bp 0x00016db39ad0 sp 0x00016db39268
READ of size 17 at 0x6040000ddd3a thread T0
    #0 0x000105c35f94 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long)+0x47c (libclang_rt.asan_osx_dynamic.dylib:arm64+0x15f94)
    #1 0x000105c36370 in memcmp+0x54 (libclang_rt.asan_osx_dynamic.dylib:arm64+0x16370)
    #2 0x0001080c386c in XS_Cpanel__JSON__XS_new XS.xs:5075
    #3 0x000103091ee8 in Perl_rpp_invoke_xs inline.h:1176
    #4 0x000103086684 in Perl_pp_entersub pp_hot.c:6558
    #5 0x00010273fdf4 in Perl_runops_debug dump.c:3003
```